### PR TITLE
Fixes #33 Changelog activated by default

### DIFF
--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/ElementDefinition/ElementDefinitionTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/ElementDefinition/ElementDefinitionTestFixture.cs
@@ -45,7 +45,7 @@ namespace WebservicesIntegrationTests
             var postBody = base.GetJsonFromFile(postBodyPath);
             var jArray = this.WebClient.PostDto(iterationUri, postBody);
 
-            Assert.AreEqual(3, jArray.Count);
+            Assert.AreEqual(4, jArray.Count);
 
             var engineeringModel = jArray.Single(
                 x => (string)x[PropertyNames.Iid] == "9ec982e4-ef72-4953-aa85-b158a95d8d56");
@@ -122,7 +122,7 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.PostDto(iterationUri, postBody);
 
             // check if there are 2 objects
-            Assert.AreEqual(2, jArray.Count);
+            Assert.AreEqual(3, jArray.Count);
 
             // get a specific EngineeringModel from the result by it's unique id
             var engineeeringModel = jArray.Single(
@@ -153,7 +153,7 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.PostDto(iterationUri, postBody);
 
             // check if there are 2 objects
-            Assert.AreEqual(2, jArray.Count);
+            Assert.AreEqual(3, jArray.Count);
 
             // get a specific EngineeringModel from the result by it's unique id
             var engineeeringModel = jArray.Single(
@@ -196,7 +196,7 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.PostDto(iterationUri, postBody);
             
             // check if there are 2 objects
-            Assert.AreEqual(2, jArray.Count);
+            Assert.AreEqual(3, jArray.Count);
 
             // get a specific EngineeringModel from the result by it's unique id
             var engineeeringModel = jArray.Single(
@@ -245,10 +245,9 @@ namespace WebservicesIntegrationTests
             IList<string> iterations = iterationsArray.Select(x => (string)x).ToList();
             CollectionAssert.AreEquivalent(expectedIterations, iterations);
 
-            var expectedLogEntries = new[] { "4e2375eb-8e37-4df2-9c7b-dd896683a891" };
             var logEntriesArray = (JArray)engineeringModel[PropertyNames.LogEntry];
             IList<string> logEntries = logEntriesArray.Select(x => (string)x).ToList();
-            CollectionAssert.AreEquivalent(expectedLogEntries, logEntries);
+            Assert.AreEqual(2, logEntries.Count);
 
             var expectedCommonFileStores = new[] { "8e5ca9cc-3da8-4e66-9172-7c3b2464a59c" };
             var commonFileStoresArray = (JArray)engineeringModel[PropertyNames.CommonFileStore];

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/Parameter/ParameterTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/Parameter/ParameterTestFixture.cs
@@ -1,6 +1,6 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ParameterTestFixture.cs" company="RHEA System">
-//   Copyright 2016 RHEA System 
+//   Copyright 2016-2021 RHEA System 
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
@@ -47,9 +47,9 @@ namespace WebservicesIntegrationTests
             Assert.AreEqual(2, jArray.Count);
 
             // get a specific Parameter from the result by it's unique id
-            var parameter = jArray.Single(x => (string)x[PropertyNames.Iid] == "6c5aff74-f983-4aa8-a9d6-293b3429307c");
+            var parameter = jArray.Single(x => (string) x[PropertyNames.Iid] == "6c5aff74-f983-4aa8-a9d6-293b3429307c");
 
-            ParameterTestFixture.VerifyProperties(parameter);
+            VerifyProperties(parameter);
         }
 
         [Test]
@@ -69,15 +69,15 @@ namespace WebservicesIntegrationTests
             Assert.AreEqual(5, jArray.Count);
 
             // get a specific Iteration from the result by it's unique id
-            var iteration = jArray.Single(x => (string)x[PropertyNames.Iid] == "e163c5ad-f32b-4387-b805-f4b34600bc2c");
+            var iteration = jArray.Single(x => (string) x[PropertyNames.Iid] == "e163c5ad-f32b-4387-b805-f4b34600bc2c");
             IterationTestFixture.VerifyProperties(iteration);
 
             // get a specific ElementDefinition from the result by it's unique id
             ElementDefinitionTestFixture.VerifyProperties(jArray);
 
             // get a specific Parameter from the result by it's unique id
-            var parameter = jArray.Single(x => (string)x[PropertyNames.Iid] == "6c5aff74-f983-4aa8-a9d6-293b3429307c");
-            ParameterTestFixture.VerifyProperties(parameter);
+            var parameter = jArray.Single(x => (string) x[PropertyNames.Iid] == "6c5aff74-f983-4aa8-a9d6-293b3429307c");
+            VerifyProperties(parameter);
         }
 
         [Test]
@@ -88,82 +88,86 @@ namespace WebservicesIntegrationTests
                     UriFormat,
                     this.Settings.Hostname,
                     "/EngineeringModel/9ec982e4-ef72-4953-aa85-b158a95d8d56/iteration/e163c5ad-f32b-4387-b805-f4b34600bc2c"));
+
             var postBodyPath = this.GetPath("Tests/EngineeringModel/Parameter/PostNewParameter.json");
 
             var postBody = this.GetJsonFromFile(postBodyPath);
             var jArray = this.WebClient.PostDto(iterationUri, postBody);
 
             var engineeeringModel = jArray.Single(
-                x => (string)x[PropertyNames.Iid] == "9ec982e4-ef72-4953-aa85-b158a95d8d56");
-            Assert.AreEqual(2, (int)engineeeringModel[PropertyNames.RevisionNumber]);
+                x => (string) x[PropertyNames.Iid] == "9ec982e4-ef72-4953-aa85-b158a95d8d56");
+
+            Assert.AreEqual(2, (int) engineeeringModel[PropertyNames.RevisionNumber]);
 
             // get a specific ElementDefinition from the result by it's unique id
             var elementDefinition = jArray.Single(
-                x => (string)x[PropertyNames.Iid] == "f73860b2-12f0-43e4-b8b2-c81862c0a159");
-            Assert.AreEqual(2, (int)elementDefinition[PropertyNames.RevisionNumber]);
+                x => (string) x[PropertyNames.Iid] == "f73860b2-12f0-43e4-b8b2-c81862c0a159");
+
+            Assert.AreEqual(2, (int) elementDefinition[PropertyNames.RevisionNumber]);
 
             var expectedParameters = new[]
-                                         {
-                                             "6c5aff74-f983-4aa8-a9d6-293b3429307c",
-                                             "3f05483f-66ff-4f21-bc76-45956779f66e",
-                                             "2cd4eb9c-e92c-41b2-968c-f03ff7010bad"
-                                         };
-            var parametersArray = (JArray)elementDefinition[PropertyNames.Parameter];
-            IList<string> parameters = parametersArray.Select(x => (string)x).ToList();
+            {
+                "6c5aff74-f983-4aa8-a9d6-293b3429307c",
+                "3f05483f-66ff-4f21-bc76-45956779f66e",
+                "2cd4eb9c-e92c-41b2-968c-f03ff7010bad"
+            };
+
+            var parametersArray = (JArray) elementDefinition[PropertyNames.Parameter];
+            IList<string> parameters = parametersArray.Select(x => (string) x).ToList();
             CollectionAssert.AreEquivalent(expectedParameters, parameters);
 
             // get the added Parameter from the result by it's unique id
-            var parameter = jArray.Single(x => (string)x[PropertyNames.Iid] == "2cd4eb9c-e92c-41b2-968c-f03ff7010bad");
+            var parameter = jArray.Single(x => (string) x[PropertyNames.Iid] == "2cd4eb9c-e92c-41b2-968c-f03ff7010bad");
 
             // verify the amount of returned properties 
             Assert.AreEqual(14, parameter.Children().Count());
 
             // assert that the properties are what is expected
-            Assert.AreEqual("2cd4eb9c-e92c-41b2-968c-f03ff7010bad", (string)parameter[PropertyNames.Iid]);
-            Assert.AreEqual(2, (int)parameter[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("Parameter", (string)parameter[PropertyNames.ClassKind]);
+            Assert.AreEqual("2cd4eb9c-e92c-41b2-968c-f03ff7010bad", (string) parameter[PropertyNames.Iid]);
+            Assert.AreEqual(2, (int) parameter[PropertyNames.RevisionNumber]);
+            Assert.AreEqual("Parameter", (string) parameter[PropertyNames.ClassKind]);
 
-            Assert.IsNull((string)parameter[PropertyNames.RequestedBy]);
-            Assert.IsFalse((bool)parameter[PropertyNames.AllowDifferentOwnerOfOverride]);
-            Assert.IsFalse((bool)parameter[PropertyNames.ExpectsOverride]);
-            Assert.AreEqual("a21c15c4-3e1e-46b5-b109-5063dec1e254", (string)parameter[PropertyNames.ParameterType]);
-            Assert.IsNull((string)parameter[PropertyNames.Scale]);
-            Assert.IsNull((string)parameter[PropertyNames.StateDependence]);
-            Assert.IsNull((string)parameter[PropertyNames.Group]);
-            Assert.IsFalse((bool)parameter[PropertyNames.IsOptionDependent]);
-            Assert.AreEqual("0e92edde-fdff-41db-9b1d-f2e484f12535", (string)parameter[PropertyNames.Owner]);
+            Assert.IsNull((string) parameter[PropertyNames.RequestedBy]);
+            Assert.IsFalse((bool) parameter[PropertyNames.AllowDifferentOwnerOfOverride]);
+            Assert.IsFalse((bool) parameter[PropertyNames.ExpectsOverride]);
+            Assert.AreEqual("a21c15c4-3e1e-46b5-b109-5063dec1e254", (string) parameter[PropertyNames.ParameterType]);
+            Assert.IsNull((string) parameter[PropertyNames.Scale]);
+            Assert.IsNull((string) parameter[PropertyNames.StateDependence]);
+            Assert.IsNull((string) parameter[PropertyNames.Group]);
+            Assert.IsFalse((bool) parameter[PropertyNames.IsOptionDependent]);
+            Assert.AreEqual("0e92edde-fdff-41db-9b1d-f2e484f12535", (string) parameter[PropertyNames.Owner]);
 
             var expectedParameterSubscriptions = new string[] { };
-            var parameterSubscriptionsArray = (JArray)parameter[PropertyNames.ParameterSubscription];
-            IList<string> parameterSubscriptions = parameterSubscriptionsArray.Select(x => (string)x).ToList();
+            var parameterSubscriptionsArray = (JArray) parameter[PropertyNames.ParameterSubscription];
+            IList<string> parameterSubscriptions = parameterSubscriptionsArray.Select(x => (string) x).ToList();
             CollectionAssert.AreEquivalent(expectedParameterSubscriptions, parameterSubscriptions);
 
             // get the created ParameterValueSet as a side effect of creating Parameter from the result by it's unique id
-            var valueSetsArray = (JArray)parameter[PropertyNames.ValueSet];
-            IList<string> valueSets = valueSetsArray.Select(x => (string)x).ToList();
+            var valueSetsArray = (JArray) parameter[PropertyNames.ValueSet];
+            IList<string> valueSets = valueSetsArray.Select(x => (string) x).ToList();
             Assert.AreEqual(1, valueSets.Count);
 
-            var parameterValueSet = jArray.Single(x => (string)x[PropertyNames.Iid] == valueSets[0]);
+            var parameterValueSet = jArray.Single(x => (string) x[PropertyNames.Iid] == valueSets[0]);
 
             // verify the amount of returned properties 
             Assert.AreEqual(11, parameterValueSet.Children().Count());
 
             // assert that the properties are what is expected
-            Assert.AreEqual(valueSets[0], (string)parameterValueSet[PropertyNames.Iid]);
-            Assert.AreEqual(2, (int)parameterValueSet[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("ParameterValueSet", (string)parameterValueSet[PropertyNames.ClassKind]);
+            Assert.AreEqual(valueSets[0], (string) parameterValueSet[PropertyNames.Iid]);
+            Assert.AreEqual(2, (int) parameterValueSet[PropertyNames.RevisionNumber]);
+            Assert.AreEqual("ParameterValueSet", (string) parameterValueSet[PropertyNames.ClassKind]);
 
-            Assert.AreEqual("MANUAL", (string)parameterValueSet[PropertyNames.ValueSwitch]);
+            Assert.AreEqual("MANUAL", (string) parameterValueSet[PropertyNames.ValueSwitch]);
 
             const string emptyProperty = "[\"-\"]";
-            Assert.AreEqual(emptyProperty, (string)parameterValueSet[PropertyNames.Published]);
-            Assert.AreEqual(emptyProperty, (string)parameterValueSet[PropertyNames.Formula]);
-            Assert.AreEqual(emptyProperty, (string)parameterValueSet[PropertyNames.Computed]);
-            Assert.AreEqual(emptyProperty, (string)parameterValueSet[PropertyNames.Manual]);
-            Assert.AreEqual(emptyProperty, (string)parameterValueSet[PropertyNames.Reference]);
+            Assert.AreEqual(emptyProperty, (string) parameterValueSet[PropertyNames.Published]);
+            Assert.AreEqual(emptyProperty, (string) parameterValueSet[PropertyNames.Formula]);
+            Assert.AreEqual(emptyProperty, (string) parameterValueSet[PropertyNames.Computed]);
+            Assert.AreEqual(emptyProperty, (string) parameterValueSet[PropertyNames.Manual]);
+            Assert.AreEqual(emptyProperty, (string) parameterValueSet[PropertyNames.Reference]);
 
-            Assert.IsNull((string)parameterValueSet[PropertyNames.ActualState]);
-            Assert.IsNull((string)parameterValueSet[PropertyNames.ActualOption]);
+            Assert.IsNull((string) parameterValueSet[PropertyNames.ActualState]);
+            Assert.IsNull((string) parameterValueSet[PropertyNames.ActualOption]);
         }
 
         [Test]
@@ -174,81 +178,85 @@ namespace WebservicesIntegrationTests
                     UriFormat,
                     this.Settings.Hostname,
                     "/EngineeringModel/9ec982e4-ef72-4953-aa85-b158a95d8d56/iteration/e163c5ad-f32b-4387-b805-f4b34600bc2c"));
+
             var postBodyPath = this.GetPath("Tests/EngineeringModel/Parameter/PostDeleteCreateParameter.json");
 
             var postBody = this.GetJsonFromFile(postBodyPath);
             var jArray = this.WebClient.PostDto(iterationUri, postBody);
 
             var engineeeringModel = jArray.Single(
-                x => (string)x[PropertyNames.Iid] == "9ec982e4-ef72-4953-aa85-b158a95d8d56");
-            Assert.AreEqual(2, (int)engineeeringModel[PropertyNames.RevisionNumber]);
+                x => (string) x[PropertyNames.Iid] == "9ec982e4-ef72-4953-aa85-b158a95d8d56");
+
+            Assert.AreEqual(2, (int) engineeeringModel[PropertyNames.RevisionNumber]);
 
             // get a specific ElementDefinition from the result by it's unique id
             var elementDefinition = jArray.Single(
-                x => (string)x[PropertyNames.Iid] == "f73860b2-12f0-43e4-b8b2-c81862c0a159");
-            Assert.AreEqual(2, (int)elementDefinition[PropertyNames.RevisionNumber]);
+                x => (string) x[PropertyNames.Iid] == "f73860b2-12f0-43e4-b8b2-c81862c0a159");
+
+            Assert.AreEqual(2, (int) elementDefinition[PropertyNames.RevisionNumber]);
 
             var expectedParameters = new[]
-                                         {
-                                             "3f05483f-66ff-4f21-bc76-45956779f66e",
-                                             "2cd4eb9c-e92c-41b2-968c-f03ff7010bad"
-                                         };
-            var parametersArray = (JArray)elementDefinition[PropertyNames.Parameter];
-            IList<string> parameters = parametersArray.Select(x => (string)x).ToList();
+            {
+                "3f05483f-66ff-4f21-bc76-45956779f66e",
+                "2cd4eb9c-e92c-41b2-968c-f03ff7010bad"
+            };
+
+            var parametersArray = (JArray) elementDefinition[PropertyNames.Parameter];
+            IList<string> parameters = parametersArray.Select(x => (string) x).ToList();
             CollectionAssert.AreEquivalent(expectedParameters, parameters);
 
             // get the added Parameter from the result by it's unique id
-            var parameter = jArray.Single(x => (string)x[PropertyNames.Iid] == "2cd4eb9c-e92c-41b2-968c-f03ff7010bad");
+            var parameter = jArray.Single(x => (string) x[PropertyNames.Iid] == "2cd4eb9c-e92c-41b2-968c-f03ff7010bad");
 
             // verify the amount of returned properties 
             Assert.AreEqual(14, parameter.Children().Count());
 
             // assert that the properties are what is expected
-            Assert.AreEqual("2cd4eb9c-e92c-41b2-968c-f03ff7010bad", (string)parameter[PropertyNames.Iid]);
-            Assert.AreEqual(2, (int)parameter[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("Parameter", (string)parameter[PropertyNames.ClassKind]);
+            Assert.AreEqual("2cd4eb9c-e92c-41b2-968c-f03ff7010bad", (string) parameter[PropertyNames.Iid]);
+            Assert.AreEqual(2, (int) parameter[PropertyNames.RevisionNumber]);
+            Assert.AreEqual("Parameter", (string) parameter[PropertyNames.ClassKind]);
 
-            Assert.IsNull((string)parameter[PropertyNames.RequestedBy]);
-            Assert.IsFalse((bool)parameter[PropertyNames.AllowDifferentOwnerOfOverride]);
-            Assert.IsFalse((bool)parameter[PropertyNames.ExpectsOverride]);
-            Assert.AreEqual("a21c15c4-3e1e-46b5-b109-5063dec1e254", (string)parameter[PropertyNames.ParameterType]);
-            Assert.IsNull((string)parameter[PropertyNames.Scale]);
-            Assert.IsNull((string)parameter[PropertyNames.StateDependence]);
-            Assert.IsNull((string)parameter[PropertyNames.Group]);
-            Assert.IsFalse((bool)parameter[PropertyNames.IsOptionDependent]);
-            Assert.AreEqual("0e92edde-fdff-41db-9b1d-f2e484f12535", (string)parameter[PropertyNames.Owner]);
+            Assert.IsNull((string) parameter[PropertyNames.RequestedBy]);
+            Assert.IsFalse((bool) parameter[PropertyNames.AllowDifferentOwnerOfOverride]);
+            Assert.IsFalse((bool) parameter[PropertyNames.ExpectsOverride]);
+            Assert.AreEqual("a21c15c4-3e1e-46b5-b109-5063dec1e254", (string) parameter[PropertyNames.ParameterType]);
+            Assert.IsNull((string) parameter[PropertyNames.Scale]);
+            Assert.IsNull((string) parameter[PropertyNames.StateDependence]);
+            Assert.IsNull((string) parameter[PropertyNames.Group]);
+            Assert.IsFalse((bool) parameter[PropertyNames.IsOptionDependent]);
+            Assert.AreEqual("0e92edde-fdff-41db-9b1d-f2e484f12535", (string) parameter[PropertyNames.Owner]);
 
             var expectedParameterSubscriptions = new string[] { };
-            var parameterSubscriptionsArray = (JArray)parameter[PropertyNames.ParameterSubscription];
-            IList<string> parameterSubscriptions = parameterSubscriptionsArray.Select(x => (string)x).ToList();
+            var parameterSubscriptionsArray = (JArray) parameter[PropertyNames.ParameterSubscription];
+            IList<string> parameterSubscriptions = parameterSubscriptionsArray.Select(x => (string) x).ToList();
             CollectionAssert.AreEquivalent(expectedParameterSubscriptions, parameterSubscriptions);
 
             // get the created ParameterValueSet as a side effect of creating Parameter from the result by it's unique id
-            var valueSetsArray = (JArray)parameter[PropertyNames.ValueSet];
-            IList<string> valueSets = valueSetsArray.Select(x => (string)x).ToList();
+            var valueSetsArray = (JArray) parameter[PropertyNames.ValueSet];
+            IList<string> valueSets = valueSetsArray.Select(x => (string) x).ToList();
             Assert.AreEqual(1, valueSets.Count);
 
-            var parameterValueSet = jArray.Single(x => (string)x[PropertyNames.Iid] == valueSets[0]);
+            var parameterValueSet = jArray.Single(x => (string) x[PropertyNames.Iid] == valueSets[0]);
 
             // verify the amount of returned properties 
             Assert.AreEqual(11, parameterValueSet.Children().Count());
 
             // assert that the properties are what is expected
-            Assert.AreEqual(valueSets[0], (string)parameterValueSet[PropertyNames.Iid]);
-            Assert.AreEqual(2, (int)parameterValueSet[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("ParameterValueSet", (string)parameterValueSet[PropertyNames.ClassKind]);
+            Assert.AreEqual(valueSets[0], (string) parameterValueSet[PropertyNames.Iid]);
+            Assert.AreEqual(2, (int) parameterValueSet[PropertyNames.RevisionNumber]);
+            Assert.AreEqual("ParameterValueSet", (string) parameterValueSet[PropertyNames.ClassKind]);
 
-            Assert.AreEqual("MANUAL", (string)parameterValueSet[PropertyNames.ValueSwitch]);
+            Assert.AreEqual("MANUAL", (string) parameterValueSet[PropertyNames.ValueSwitch]);
 
             const string emptyProperty = "[\"-\"]";
-            Assert.AreEqual(emptyProperty, (string)parameterValueSet[PropertyNames.Published]);
-            Assert.AreEqual(emptyProperty, (string)parameterValueSet[PropertyNames.Formula]);
-            Assert.AreEqual(emptyProperty, (string)parameterValueSet[PropertyNames.Computed]);
-            Assert.AreEqual(emptyProperty, (string)parameterValueSet[PropertyNames.Manual]);
-            Assert.AreEqual(emptyProperty, (string)parameterValueSet[PropertyNames.Reference]);
+            Assert.AreEqual(emptyProperty, (string) parameterValueSet[PropertyNames.Published]);
+            Assert.AreEqual(emptyProperty, (string) parameterValueSet[PropertyNames.Formula]);
+            Assert.AreEqual(emptyProperty, (string) parameterValueSet[PropertyNames.Computed]);
+            Assert.AreEqual(emptyProperty, (string) parameterValueSet[PropertyNames.Manual]);
+            Assert.AreEqual(emptyProperty, (string) parameterValueSet[PropertyNames.Reference]);
 
-            Assert.IsNull((string)parameterValueSet[PropertyNames.ActualState]);
-            Assert.IsNull((string)parameterValueSet[PropertyNames.ActualOption]);
+            Assert.IsNull((string) parameterValueSet[PropertyNames.ActualState]);
+            Assert.IsNull((string) parameterValueSet[PropertyNames.ActualOption]);
         }
 
         [Test]
@@ -259,6 +267,7 @@ namespace WebservicesIntegrationTests
                     UriFormat,
                     this.Settings.Hostname,
                     "/EngineeringModel/9ec982e4-ef72-4953-aa85-b158a95d8d56/iteration/e163c5ad-f32b-4387-b805-f4b34600bc2c"));
+
             var postBodyPath = this.GetPath(
                 "Tests/EngineeringModel/Parameter/PostNewParameterOfCompoundParameterType.json");
 
@@ -266,76 +275,79 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.PostDto(iterationUri, postBody);
 
             var engineeeringModel = jArray.Single(
-                x => (string)x[PropertyNames.Iid] == "9ec982e4-ef72-4953-aa85-b158a95d8d56");
-            Assert.AreEqual(2, (int)engineeeringModel[PropertyNames.RevisionNumber]);
+                x => (string) x[PropertyNames.Iid] == "9ec982e4-ef72-4953-aa85-b158a95d8d56");
+
+            Assert.AreEqual(2, (int) engineeeringModel[PropertyNames.RevisionNumber]);
 
             // get a specific ElementDefinition from the result by it's unique id
             var elementDefinition = jArray.Single(
-                x => (string)x[PropertyNames.Iid] == "f73860b2-12f0-43e4-b8b2-c81862c0a159");
-            Assert.AreEqual(2, (int)elementDefinition[PropertyNames.RevisionNumber]);
+                x => (string) x[PropertyNames.Iid] == "f73860b2-12f0-43e4-b8b2-c81862c0a159");
+
+            Assert.AreEqual(2, (int) elementDefinition[PropertyNames.RevisionNumber]);
 
             var expectedParameters = new[]
-                                         {
-                                             "6c5aff74-f983-4aa8-a9d6-293b3429307c",
-                                             "3f05483f-66ff-4f21-bc76-45956779f66e",
-                                             "2460b6a5-08ff-4cc3-a2cc-8fd5c5cf2736"
-                                         };
-            var parametersArray = (JArray)elementDefinition[PropertyNames.Parameter];
-            IList<string> parameters = parametersArray.Select(x => (string)x).ToList();
+            {
+                "6c5aff74-f983-4aa8-a9d6-293b3429307c",
+                "3f05483f-66ff-4f21-bc76-45956779f66e",
+                "2460b6a5-08ff-4cc3-a2cc-8fd5c5cf2736"
+            };
+
+            var parametersArray = (JArray) elementDefinition[PropertyNames.Parameter];
+            IList<string> parameters = parametersArray.Select(x => (string) x).ToList();
             CollectionAssert.AreEquivalent(expectedParameters, parameters);
 
             // get the added Parameter from the result by it's unique id
-            var parameter = jArray.Single(x => (string)x[PropertyNames.Iid] == "2460b6a5-08ff-4cc3-a2cc-8fd5c5cf2736");
+            var parameter = jArray.Single(x => (string) x[PropertyNames.Iid] == "2460b6a5-08ff-4cc3-a2cc-8fd5c5cf2736");
 
             // verify the amount of returned properties 
             Assert.AreEqual(14, parameter.Children().Count());
 
             // assert that the properties are what is expected
-            Assert.AreEqual("2460b6a5-08ff-4cc3-a2cc-8fd5c5cf2736", (string)parameter[PropertyNames.Iid]);
-            Assert.AreEqual(2, (int)parameter[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("Parameter", (string)parameter[PropertyNames.ClassKind]);
+            Assert.AreEqual("2460b6a5-08ff-4cc3-a2cc-8fd5c5cf2736", (string) parameter[PropertyNames.Iid]);
+            Assert.AreEqual(2, (int) parameter[PropertyNames.RevisionNumber]);
+            Assert.AreEqual("Parameter", (string) parameter[PropertyNames.ClassKind]);
 
-            Assert.IsNull((string)parameter[PropertyNames.RequestedBy]);
-            Assert.IsFalse((bool)parameter[PropertyNames.AllowDifferentOwnerOfOverride]);
-            Assert.IsFalse((bool)parameter[PropertyNames.ExpectsOverride]);
-            Assert.AreEqual("4a783624-b2bc-4e6d-95b3-11d036f6e917", (string)parameter[PropertyNames.ParameterType]);
-            Assert.IsNull((string)parameter[PropertyNames.Scale]);
-            Assert.IsNull((string)parameter[PropertyNames.StateDependence]);
-            Assert.IsNull((string)parameter[PropertyNames.Group]);
-            Assert.IsFalse((bool)parameter[PropertyNames.IsOptionDependent]);
-            Assert.AreEqual("0e92edde-fdff-41db-9b1d-f2e484f12535", (string)parameter[PropertyNames.Owner]);
+            Assert.IsNull((string) parameter[PropertyNames.RequestedBy]);
+            Assert.IsFalse((bool) parameter[PropertyNames.AllowDifferentOwnerOfOverride]);
+            Assert.IsFalse((bool) parameter[PropertyNames.ExpectsOverride]);
+            Assert.AreEqual("4a783624-b2bc-4e6d-95b3-11d036f6e917", (string) parameter[PropertyNames.ParameterType]);
+            Assert.IsNull((string) parameter[PropertyNames.Scale]);
+            Assert.IsNull((string) parameter[PropertyNames.StateDependence]);
+            Assert.IsNull((string) parameter[PropertyNames.Group]);
+            Assert.IsFalse((bool) parameter[PropertyNames.IsOptionDependent]);
+            Assert.AreEqual("0e92edde-fdff-41db-9b1d-f2e484f12535", (string) parameter[PropertyNames.Owner]);
 
             var expectedParameterSubscriptions = new string[] { };
-            var parameterSubscriptionsArray = (JArray)parameter[PropertyNames.ParameterSubscription];
-            IList<string> parameterSubscriptions = parameterSubscriptionsArray.Select(x => (string)x).ToList();
+            var parameterSubscriptionsArray = (JArray) parameter[PropertyNames.ParameterSubscription];
+            IList<string> parameterSubscriptions = parameterSubscriptionsArray.Select(x => (string) x).ToList();
             CollectionAssert.AreEquivalent(expectedParameterSubscriptions, parameterSubscriptions);
 
             // get the created ParameterValueSet as a side effect of creating Parameter from the result by it's unique id
-            var valueSetsArray = (JArray)parameter[PropertyNames.ValueSet];
-            IList<string> valueSets = valueSetsArray.Select(x => (string)x).ToList();
+            var valueSetsArray = (JArray) parameter[PropertyNames.ValueSet];
+            IList<string> valueSets = valueSetsArray.Select(x => (string) x).ToList();
             Assert.AreEqual(1, valueSets.Count);
 
-            var parameterValueSet = jArray.Single(x => (string)x[PropertyNames.Iid] == valueSets[0]);
+            var parameterValueSet = jArray.Single(x => (string) x[PropertyNames.Iid] == valueSets[0]);
 
             // verify the amount of returned properties 
             Assert.AreEqual(11, parameterValueSet.Children().Count());
 
             // assert that the properties are what is expected
-            Assert.AreEqual(valueSets[0], (string)parameterValueSet[PropertyNames.Iid]);
-            Assert.AreEqual(2, (int)parameterValueSet[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("ParameterValueSet", (string)parameterValueSet[PropertyNames.ClassKind]);
+            Assert.AreEqual(valueSets[0], (string) parameterValueSet[PropertyNames.Iid]);
+            Assert.AreEqual(2, (int) parameterValueSet[PropertyNames.RevisionNumber]);
+            Assert.AreEqual("ParameterValueSet", (string) parameterValueSet[PropertyNames.ClassKind]);
 
-            Assert.AreEqual("MANUAL", (string)parameterValueSet[PropertyNames.ValueSwitch]);
+            Assert.AreEqual("MANUAL", (string) parameterValueSet[PropertyNames.ValueSwitch]);
 
             const string emptyProperty = "[\"-\",\"-\"]";
-            Assert.AreEqual(emptyProperty, (string)parameterValueSet[PropertyNames.Published]);
-            Assert.AreEqual(emptyProperty, (string)parameterValueSet[PropertyNames.Formula]);
-            Assert.AreEqual(emptyProperty, (string)parameterValueSet[PropertyNames.Computed]);
-            Assert.AreEqual(emptyProperty, (string)parameterValueSet[PropertyNames.Manual]);
-            Assert.AreEqual(emptyProperty, (string)parameterValueSet[PropertyNames.Reference]);
+            Assert.AreEqual(emptyProperty, (string) parameterValueSet[PropertyNames.Published]);
+            Assert.AreEqual(emptyProperty, (string) parameterValueSet[PropertyNames.Formula]);
+            Assert.AreEqual(emptyProperty, (string) parameterValueSet[PropertyNames.Computed]);
+            Assert.AreEqual(emptyProperty, (string) parameterValueSet[PropertyNames.Manual]);
+            Assert.AreEqual(emptyProperty, (string) parameterValueSet[PropertyNames.Reference]);
 
-            Assert.IsNull((string)parameterValueSet[PropertyNames.ActualState]);
-            Assert.IsNull((string)parameterValueSet[PropertyNames.ActualOption]);
+            Assert.IsNull((string) parameterValueSet[PropertyNames.ActualState]);
+            Assert.IsNull((string) parameterValueSet[PropertyNames.ActualOption]);
         }
 
         [Test]
@@ -346,84 +358,89 @@ namespace WebservicesIntegrationTests
                     UriFormat,
                     this.Settings.Hostname,
                     "/EngineeringModel/9ec982e4-ef72-4953-aa85-b158a95d8d56/iteration/e163c5ad-f32b-4387-b805-f4b34600bc2c"));
+
             var postBodyPath = this.GetPath("Tests/EngineeringModel/Parameter/PostNewOptionDependentParameter.json");
 
             var postBody = this.GetJsonFromFile(postBodyPath);
             var jArray = this.WebClient.PostDto(iterationUri, postBody);
 
             var engineeeringModel = jArray.Single(
-                x => (string)x[PropertyNames.Iid] == "9ec982e4-ef72-4953-aa85-b158a95d8d56");
-            Assert.AreEqual(2, (int)engineeeringModel[PropertyNames.RevisionNumber]);
+                x => (string) x[PropertyNames.Iid] == "9ec982e4-ef72-4953-aa85-b158a95d8d56");
+
+            Assert.AreEqual(2, (int) engineeeringModel[PropertyNames.RevisionNumber]);
 
             // get a specific ElementDefinition from the result by it's unique id
             var elementDefinition = jArray.Single(
-                x => (string)x[PropertyNames.Iid] == "f73860b2-12f0-43e4-b8b2-c81862c0a159");
-            Assert.AreEqual(2, (int)elementDefinition[PropertyNames.RevisionNumber]);
+                x => (string) x[PropertyNames.Iid] == "f73860b2-12f0-43e4-b8b2-c81862c0a159");
+
+            Assert.AreEqual(2, (int) elementDefinition[PropertyNames.RevisionNumber]);
 
             var expectedParameters = new[]
-                                         {
-                                             "6c5aff74-f983-4aa8-a9d6-293b3429307c",
-                                             "3f05483f-66ff-4f21-bc76-45956779f66e",
-                                             "9600b225-a4be-47b1-92b1-4dc2d8894ea3"
-                                         };
-            var parametersArray = (JArray)elementDefinition[PropertyNames.Parameter];
-            IList<string> parameters = parametersArray.Select(x => (string)x).ToList();
+            {
+                "6c5aff74-f983-4aa8-a9d6-293b3429307c",
+                "3f05483f-66ff-4f21-bc76-45956779f66e",
+                "9600b225-a4be-47b1-92b1-4dc2d8894ea3"
+            };
+
+            var parametersArray = (JArray) elementDefinition[PropertyNames.Parameter];
+            IList<string> parameters = parametersArray.Select(x => (string) x).ToList();
             CollectionAssert.AreEquivalent(expectedParameters, parameters);
 
             // get the added Parameter from the result by it's unique id
-            var parameter = jArray.Single(x => (string)x[PropertyNames.Iid] == "9600b225-a4be-47b1-92b1-4dc2d8894ea3");
+            var parameter = jArray.Single(x => (string) x[PropertyNames.Iid] == "9600b225-a4be-47b1-92b1-4dc2d8894ea3");
 
             // verify the amount of returned properties 
             Assert.AreEqual(14, parameter.Children().Count());
 
             // assert that the properties are what is expected
-            Assert.AreEqual("9600b225-a4be-47b1-92b1-4dc2d8894ea3", (string)parameter[PropertyNames.Iid]);
-            Assert.AreEqual(2, (int)parameter[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("Parameter", (string)parameter[PropertyNames.ClassKind]);
+            Assert.AreEqual("9600b225-a4be-47b1-92b1-4dc2d8894ea3", (string) parameter[PropertyNames.Iid]);
+            Assert.AreEqual(2, (int) parameter[PropertyNames.RevisionNumber]);
+            Assert.AreEqual("Parameter", (string) parameter[PropertyNames.ClassKind]);
 
-            Assert.IsNull((string)parameter[PropertyNames.RequestedBy]);
-            Assert.IsFalse((bool)parameter[PropertyNames.AllowDifferentOwnerOfOverride]);
-            Assert.IsFalse((bool)parameter[PropertyNames.ExpectsOverride]);
-            Assert.AreEqual("a21c15c4-3e1e-46b5-b109-5063dec1e254", (string)parameter[PropertyNames.ParameterType]);
-            Assert.IsNull((string)parameter[PropertyNames.Scale]);
-            Assert.IsNull((string)parameter[PropertyNames.StateDependence]);
-            Assert.IsNull((string)parameter[PropertyNames.Group]);
-            Assert.IsTrue((bool)parameter[PropertyNames.IsOptionDependent]);
-            Assert.AreEqual("0e92edde-fdff-41db-9b1d-f2e484f12535", (string)parameter[PropertyNames.Owner]);
+            Assert.IsNull((string) parameter[PropertyNames.RequestedBy]);
+            Assert.IsFalse((bool) parameter[PropertyNames.AllowDifferentOwnerOfOverride]);
+            Assert.IsFalse((bool) parameter[PropertyNames.ExpectsOverride]);
+            Assert.AreEqual("a21c15c4-3e1e-46b5-b109-5063dec1e254", (string) parameter[PropertyNames.ParameterType]);
+            Assert.IsNull((string) parameter[PropertyNames.Scale]);
+            Assert.IsNull((string) parameter[PropertyNames.StateDependence]);
+            Assert.IsNull((string) parameter[PropertyNames.Group]);
+            Assert.IsTrue((bool) parameter[PropertyNames.IsOptionDependent]);
+            Assert.AreEqual("0e92edde-fdff-41db-9b1d-f2e484f12535", (string) parameter[PropertyNames.Owner]);
 
             var expectedParameterSubscriptions = new string[] { };
-            var parameterSubscriptionsArray = (JArray)parameter[PropertyNames.ParameterSubscription];
-            IList<string> parameterSubscriptions = parameterSubscriptionsArray.Select(x => (string)x).ToList();
+            var parameterSubscriptionsArray = (JArray) parameter[PropertyNames.ParameterSubscription];
+            IList<string> parameterSubscriptions = parameterSubscriptionsArray.Select(x => (string) x).ToList();
             CollectionAssert.AreEquivalent(expectedParameterSubscriptions, parameterSubscriptions);
 
             // get the created ParameterValueSet as a side effect of creating Parameter from the result by it's unique id
-            var valueSetsArray = (JArray)parameter[PropertyNames.ValueSet];
-            IList<string> valueSets = valueSetsArray.Select(x => (string)x).ToList();
+            var valueSetsArray = (JArray) parameter[PropertyNames.ValueSet];
+            IList<string> valueSets = valueSetsArray.Select(x => (string) x).ToList();
             Assert.AreEqual(1, valueSets.Count);
 
-            var parameterValueSet = jArray.Single(x => (string)x[PropertyNames.Iid] == valueSets[0]);
+            var parameterValueSet = jArray.Single(x => (string) x[PropertyNames.Iid] == valueSets[0]);
 
             // verify the amount of returned properties 
             Assert.AreEqual(11, parameterValueSet.Children().Count());
 
             // assert that the properties are what is expected
-            Assert.AreEqual(valueSets[0], (string)parameterValueSet[PropertyNames.Iid]);
-            Assert.AreEqual(2, (int)parameterValueSet[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("ParameterValueSet", (string)parameterValueSet[PropertyNames.ClassKind]);
+            Assert.AreEqual(valueSets[0], (string) parameterValueSet[PropertyNames.Iid]);
+            Assert.AreEqual(2, (int) parameterValueSet[PropertyNames.RevisionNumber]);
+            Assert.AreEqual("ParameterValueSet", (string) parameterValueSet[PropertyNames.ClassKind]);
 
-            Assert.AreEqual("MANUAL", (string)parameterValueSet[PropertyNames.ValueSwitch]);
+            Assert.AreEqual("MANUAL", (string) parameterValueSet[PropertyNames.ValueSwitch]);
 
             const string emptyProperty = "[\"-\"]";
-            Assert.AreEqual(emptyProperty, (string)parameterValueSet[PropertyNames.Published]);
-            Assert.AreEqual(emptyProperty, (string)parameterValueSet[PropertyNames.Formula]);
-            Assert.AreEqual(emptyProperty, (string)parameterValueSet[PropertyNames.Computed]);
-            Assert.AreEqual(emptyProperty, (string)parameterValueSet[PropertyNames.Manual]);
-            Assert.AreEqual(emptyProperty, (string)parameterValueSet[PropertyNames.Reference]);
+            Assert.AreEqual(emptyProperty, (string) parameterValueSet[PropertyNames.Published]);
+            Assert.AreEqual(emptyProperty, (string) parameterValueSet[PropertyNames.Formula]);
+            Assert.AreEqual(emptyProperty, (string) parameterValueSet[PropertyNames.Computed]);
+            Assert.AreEqual(emptyProperty, (string) parameterValueSet[PropertyNames.Manual]);
+            Assert.AreEqual(emptyProperty, (string) parameterValueSet[PropertyNames.Reference]);
 
-            Assert.IsNull((string)parameterValueSet[PropertyNames.ActualState]);
+            Assert.IsNull((string) parameterValueSet[PropertyNames.ActualState]);
+
             Assert.AreEqual(
                 "bebcc9f4-ff20-4569-bbf6-d1acf27a8107",
-                (string)parameterValueSet[PropertyNames.ActualOption]);
+                (string) parameterValueSet[PropertyNames.ActualOption]);
         }
 
         [Test]
@@ -434,6 +451,7 @@ namespace WebservicesIntegrationTests
                     UriFormat,
                     this.Settings.Hostname,
                     "/EngineeringModel/9ec982e4-ef72-4953-aa85-b158a95d8d56/iteration/e163c5ad-f32b-4387-b805-f4b34600bc2c"));
+
             var postBodyPath = this.GetPath(
                 "Tests/EngineeringModel/Parameter/PostUpdateParameterToOptionDependent.json");
 
@@ -441,46 +459,54 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.PostDto(iterationUri, postBody);
 
             var engineeeringModel = jArray.Single(
-                x => (string)x[PropertyNames.Iid] == "9ec982e4-ef72-4953-aa85-b158a95d8d56");
-            Assert.AreEqual(2, (int)engineeeringModel[PropertyNames.RevisionNumber]);
+                x => (string) x[PropertyNames.Iid] == "9ec982e4-ef72-4953-aa85-b158a95d8d56");
 
-            var parameterValueSet = jArray.Single(x => (string)x[PropertyNames.ClassKind] == "ParameterValueSet");
-            Assert.AreEqual(2, (int)parameterValueSet[PropertyNames.RevisionNumber]);
+            Assert.AreEqual(2, (int) engineeeringModel[PropertyNames.RevisionNumber]);
+
+            var parameterValueSet = jArray.Single(x => (string) x[PropertyNames.ClassKind] == "ParameterValueSet");
+            Assert.AreEqual(2, (int) parameterValueSet[PropertyNames.RevisionNumber]);
 
             var parameterOverrideValueSet = jArray.Single(
-                x => (string)x[PropertyNames.ClassKind] == "ParameterOverrideValueSet");
-            Assert.AreEqual(2, (int)parameterOverrideValueSet[PropertyNames.RevisionNumber]);
+                x => (string) x[PropertyNames.ClassKind] == "ParameterOverrideValueSet");
+
+            Assert.AreEqual(2, (int) parameterOverrideValueSet[PropertyNames.RevisionNumber]);
+
             Assert.AreEqual(
-                (string)parameterValueSet[PropertyNames.Iid],
-                (string)parameterOverrideValueSet[PropertyNames.ParameterValueSet]);
+                (string) parameterValueSet[PropertyNames.Iid],
+                (string) parameterOverrideValueSet[PropertyNames.ParameterValueSet]);
 
             var parameterSubscriptionValueSet =
-                jArray.Single(x => (string)x[PropertyNames.ClassKind] == "ParameterSubscriptionValueSet");
-            Assert.AreEqual(2, (int)parameterSubscriptionValueSet[PropertyNames.RevisionNumber]);
+                jArray.Single(x => (string) x[PropertyNames.ClassKind] == "ParameterSubscriptionValueSet");
+
+            Assert.AreEqual(2, (int) parameterSubscriptionValueSet[PropertyNames.RevisionNumber]);
+
             Assert.AreEqual(
-                (string)parameterValueSet[PropertyNames.Iid],
-                (string)parameterSubscriptionValueSet[PropertyNames.SubscribedValueSet]);
+                (string) parameterValueSet[PropertyNames.Iid],
+                (string) parameterSubscriptionValueSet[PropertyNames.SubscribedValueSet]);
 
             var parameterSubscription = jArray.Single(
-                x => (string)x[PropertyNames.Iid] == "f1f076c4-5307-42b8-a171-3263a9e7bb21");
-            Assert.AreEqual(2, (int)parameterSubscription[PropertyNames.RevisionNumber]);
-            Assert.AreEqual(
-                (string)parameterSubscriptionValueSet[PropertyNames.Iid],
-                (string)parameterSubscription[PropertyNames.ValueSet][0]);
+                x => (string) x[PropertyNames.Iid] == "f1f076c4-5307-42b8-a171-3263a9e7bb21");
 
-            var parameter = jArray.Single(x => (string)x[PropertyNames.Iid] == "6c5aff74-f983-4aa8-a9d6-293b3429307c");
-            Assert.AreEqual(2, (int)parameter[PropertyNames.RevisionNumber]);
-            var expectedValueSets = new[] { (string)parameterValueSet[PropertyNames.Iid] };
-            var valueSetsArray = (JArray)parameter[PropertyNames.ValueSet];
-            IList<string> valueSets = valueSetsArray.Select(x => (string)x).ToList();
+            Assert.AreEqual(2, (int) parameterSubscription[PropertyNames.RevisionNumber]);
+
+            Assert.AreEqual(
+                (string) parameterSubscriptionValueSet[PropertyNames.Iid],
+                (string) parameterSubscription[PropertyNames.ValueSet][0]);
+
+            var parameter = jArray.Single(x => (string) x[PropertyNames.Iid] == "6c5aff74-f983-4aa8-a9d6-293b3429307c");
+            Assert.AreEqual(2, (int) parameter[PropertyNames.RevisionNumber]);
+            var expectedValueSets = new[] { (string) parameterValueSet[PropertyNames.Iid] };
+            var valueSetsArray = (JArray) parameter[PropertyNames.ValueSet];
+            IList<string> valueSets = valueSetsArray.Select(x => (string) x).ToList();
             CollectionAssert.AreEquivalent(expectedValueSets, valueSets);
 
             var parameterOverride = jArray.Single(
-                x => (string)x[PropertyNames.Iid] == "93f767ed-4d22-45f6-ae97-d1dab0d36e1c");
-            Assert.AreEqual(2, (int)parameterOverride[PropertyNames.RevisionNumber]);
-            expectedValueSets = new[] { (string)parameterOverrideValueSet[PropertyNames.Iid] };
-            valueSetsArray = (JArray)parameterOverride[PropertyNames.ValueSet];
-            valueSets = valueSetsArray.Select(x => (string)x).ToList();
+                x => (string) x[PropertyNames.Iid] == "93f767ed-4d22-45f6-ae97-d1dab0d36e1c");
+
+            Assert.AreEqual(2, (int) parameterOverride[PropertyNames.RevisionNumber]);
+            expectedValueSets = new[] { (string) parameterOverrideValueSet[PropertyNames.Iid] };
+            valueSetsArray = (JArray) parameterOverride[PropertyNames.ValueSet];
+            valueSets = valueSetsArray.Select(x => (string) x).ToList();
             CollectionAssert.AreEquivalent(expectedValueSets, valueSets);
         }
 
@@ -492,6 +518,7 @@ namespace WebservicesIntegrationTests
                     UriFormat,
                     this.Settings.Hostname,
                     "/EngineeringModel/9ec982e4-ef72-4953-aa85-b158a95d8d56/iteration/e163c5ad-f32b-4387-b805-f4b34600bc2c"));
+
             var postBodyPath = this.GetPath(
                 "Tests/EngineeringModel/Parameter/PostUpdateParameterToStateDependent.json");
 
@@ -499,80 +526,159 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.PostDto(iterationUri, postBody);
 
             var engineeeringModel = jArray.Single(
-                x => (string)x[PropertyNames.Iid] == "9ec982e4-ef72-4953-aa85-b158a95d8d56");
-            Assert.AreEqual(2, (int)engineeeringModel[PropertyNames.RevisionNumber]);
+                x => (string) x[PropertyNames.Iid] == "9ec982e4-ef72-4953-aa85-b158a95d8d56");
 
-            var parameterValueSet = jArray.Single(x => (string)x[PropertyNames.ClassKind] == "ParameterValueSet");
-            Assert.AreEqual(2, (int)parameterValueSet[PropertyNames.RevisionNumber]);
+            Assert.AreEqual(2, (int) engineeeringModel[PropertyNames.RevisionNumber]);
+
+            var parameterValueSet = jArray.Single(x => (string) x[PropertyNames.ClassKind] == "ParameterValueSet");
+            Assert.AreEqual(2, (int) parameterValueSet[PropertyNames.RevisionNumber]);
 
             const string EmptyProperty = "[\"-\"]";
-            Assert.AreEqual("MANUAL", (string)parameterValueSet[PropertyNames.ValueSwitch]);
-            Assert.AreEqual(EmptyProperty, (string)parameterValueSet[PropertyNames.Published]);
-            Assert.AreEqual(EmptyProperty, (string)parameterValueSet[PropertyNames.Formula]);
-            Assert.AreEqual(EmptyProperty, (string)parameterValueSet[PropertyNames.Computed]);
-            Assert.AreEqual(EmptyProperty, (string)parameterValueSet[PropertyNames.Manual]);
-            Assert.AreEqual(EmptyProperty, (string)parameterValueSet[PropertyNames.Reference]);
+            Assert.AreEqual("MANUAL", (string) parameterValueSet[PropertyNames.ValueSwitch]);
+            Assert.AreEqual(EmptyProperty, (string) parameterValueSet[PropertyNames.Published]);
+            Assert.AreEqual(EmptyProperty, (string) parameterValueSet[PropertyNames.Formula]);
+            Assert.AreEqual(EmptyProperty, (string) parameterValueSet[PropertyNames.Computed]);
+            Assert.AreEqual(EmptyProperty, (string) parameterValueSet[PropertyNames.Manual]);
+            Assert.AreEqual(EmptyProperty, (string) parameterValueSet[PropertyNames.Reference]);
 
             Assert.AreEqual(
                 "b91bfdbb-4277-4a03-b519-e4db839ef5d4",
-                (string)parameterValueSet[PropertyNames.ActualState]);
-            Assert.IsNull((string)parameterValueSet[PropertyNames.ActualOption]);
+                (string) parameterValueSet[PropertyNames.ActualState]);
 
-            var parameterOverride = jArray.Single(x => (string)x[PropertyNames.ClassKind] == "ParameterOverride");
-            Assert.AreEqual(2, (int)parameterOverride[PropertyNames.RevisionNumber]);
-            var valueSetsArray = (JArray)parameterOverride[PropertyNames.ValueSet];
-            var valueSets = valueSetsArray.Select(x => (string)x).ToList();
+            Assert.IsNull((string) parameterValueSet[PropertyNames.ActualOption]);
+
+            var parameterOverride = jArray.Single(x => (string) x[PropertyNames.ClassKind] == "ParameterOverride");
+            Assert.AreEqual(2, (int) parameterOverride[PropertyNames.RevisionNumber]);
+            var valueSetsArray = (JArray) parameterOverride[PropertyNames.ValueSet];
+            var valueSets = valueSetsArray.Select(x => (string) x).ToList();
             Assert.AreEqual(1, valueSets.Count);
-            Assert.AreEqual("0e92edde-fdff-41db-9b1d-f2e484f12535", (string)parameterOverride[PropertyNames.Owner]);
-            Assert.AreEqual("6c5aff74-f983-4aa8-a9d6-293b3429307c", (string)parameterOverride[PropertyNames.Parameter]);
+            Assert.AreEqual("0e92edde-fdff-41db-9b1d-f2e484f12535", (string) parameterOverride[PropertyNames.Owner]);
+            Assert.AreEqual("6c5aff74-f983-4aa8-a9d6-293b3429307c", (string) parameterOverride[PropertyNames.Parameter]);
 
             var expectedParameterSubscriptions = new string[] { };
-            var parameterSubscriptionsArray = (JArray)parameterOverride[PropertyNames.ParameterSubscription];
-            IList<string> parameterSubscriptions = parameterSubscriptionsArray.Select(x => (string)x).ToList();
+            var parameterSubscriptionsArray = (JArray) parameterOverride[PropertyNames.ParameterSubscription];
+            IList<string> parameterSubscriptions = parameterSubscriptionsArray.Select(x => (string) x).ToList();
             CollectionAssert.AreEquivalent(expectedParameterSubscriptions, parameterSubscriptions);
 
             var parameterOverrideValueSet = jArray.Single(
-                x => (string)x[PropertyNames.Iid] == (string)parameterOverride[PropertyNames.ValueSet][0]);
-            Assert.AreEqual(2, (int)parameterOverrideValueSet[PropertyNames.RevisionNumber]);
-            Assert.AreEqual(
-                (string)parameterValueSet[PropertyNames.Iid],
-                (string)parameterOverrideValueSet[PropertyNames.ParameterValueSet]);
-            Assert.AreEqual("MANUAL", (string)parameterOverrideValueSet[PropertyNames.ValueSwitch]);
+                x => (string) x[PropertyNames.Iid] == (string) parameterOverride[PropertyNames.ValueSet][0]);
 
-            Assert.AreEqual(EmptyProperty, (string)parameterOverrideValueSet[PropertyNames.Published]);
-            Assert.AreEqual(EmptyProperty, (string)parameterOverrideValueSet[PropertyNames.Formula]);
-            Assert.AreEqual(EmptyProperty, (string)parameterOverrideValueSet[PropertyNames.Computed]);
-            Assert.AreEqual(EmptyProperty, (string)parameterOverrideValueSet[PropertyNames.Manual]);
-            Assert.AreEqual(EmptyProperty, (string)parameterOverrideValueSet[PropertyNames.Reference]);
+            Assert.AreEqual(2, (int) parameterOverrideValueSet[PropertyNames.RevisionNumber]);
+
+            Assert.AreEqual(
+                (string) parameterValueSet[PropertyNames.Iid],
+                (string) parameterOverrideValueSet[PropertyNames.ParameterValueSet]);
+
+            Assert.AreEqual("MANUAL", (string) parameterOverrideValueSet[PropertyNames.ValueSwitch]);
+
+            Assert.AreEqual(EmptyProperty, (string) parameterOverrideValueSet[PropertyNames.Published]);
+            Assert.AreEqual(EmptyProperty, (string) parameterOverrideValueSet[PropertyNames.Formula]);
+            Assert.AreEqual(EmptyProperty, (string) parameterOverrideValueSet[PropertyNames.Computed]);
+            Assert.AreEqual(EmptyProperty, (string) parameterOverrideValueSet[PropertyNames.Manual]);
+            Assert.AreEqual(EmptyProperty, (string) parameterOverrideValueSet[PropertyNames.Reference]);
 
             var parameterSubscription = jArray.Single(
-                x => (string)x[PropertyNames.Iid] == "f1f076c4-5307-42b8-a171-3263a9e7bb21");
-            Assert.AreEqual(2, (int)parameterSubscription[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("0e92edde-fdff-41db-9b1d-f2e484f12535", (string)parameterOverride[PropertyNames.Owner]);
+                x => (string) x[PropertyNames.Iid] == "f1f076c4-5307-42b8-a171-3263a9e7bb21");
 
-            valueSetsArray = (JArray)parameterSubscription[PropertyNames.ValueSet];
-            valueSets = valueSetsArray.Select(x => (string)x).ToList();
+            Assert.AreEqual(2, (int) parameterSubscription[PropertyNames.RevisionNumber]);
+            Assert.AreEqual("0e92edde-fdff-41db-9b1d-f2e484f12535", (string) parameterOverride[PropertyNames.Owner]);
+
+            valueSetsArray = (JArray) parameterSubscription[PropertyNames.ValueSet];
+            valueSets = valueSetsArray.Select(x => (string) x).ToList();
             Assert.AreEqual(1, valueSets.Count);
 
             var parameterSubscriptionValueSet = jArray.Single(
-                x => (string)x[PropertyNames.Iid] == (string)parameterSubscription[PropertyNames.ValueSet][0]);
-            Assert.AreEqual(2, (int)parameterSubscriptionValueSet[PropertyNames.RevisionNumber]);
-            Assert.AreEqual(
-                (string)parameterValueSet[PropertyNames.Iid],
-                (string)parameterSubscriptionValueSet[PropertyNames.SubscribedValueSet]);
-            Assert.AreEqual(
-                (string)parameterValueSet[PropertyNames.Iid],
-                (string)parameterSubscriptionValueSet[PropertyNames.SubscribedValueSet]);
-            Assert.AreEqual(EmptyProperty, (string)parameterSubscriptionValueSet[PropertyNames.Manual]);
-            Assert.AreEqual("MANUAL", (string)parameterSubscriptionValueSet[PropertyNames.ValueSwitch]);
+                x => (string) x[PropertyNames.Iid] == (string) parameterSubscription[PropertyNames.ValueSet][0]);
 
-            var parameter = jArray.Single(x => (string)x[PropertyNames.Iid] == "6c5aff74-f983-4aa8-a9d6-293b3429307c");
-            Assert.AreEqual(2, (int)parameter[PropertyNames.RevisionNumber]);
-            var expectedValueSets = new[] { (string)parameterValueSet[PropertyNames.Iid] };
-            valueSetsArray = (JArray)parameter[PropertyNames.ValueSet];
-            valueSets = valueSetsArray.Select(x => (string)x).ToList();
+            Assert.AreEqual(2, (int) parameterSubscriptionValueSet[PropertyNames.RevisionNumber]);
+
+            Assert.AreEqual(
+                (string) parameterValueSet[PropertyNames.Iid],
+                (string) parameterSubscriptionValueSet[PropertyNames.SubscribedValueSet]);
+
+            Assert.AreEqual(
+                (string) parameterValueSet[PropertyNames.Iid],
+                (string) parameterSubscriptionValueSet[PropertyNames.SubscribedValueSet]);
+
+            Assert.AreEqual(EmptyProperty, (string) parameterSubscriptionValueSet[PropertyNames.Manual]);
+            Assert.AreEqual("MANUAL", (string) parameterSubscriptionValueSet[PropertyNames.ValueSwitch]);
+
+            var parameter = jArray.Single(x => (string) x[PropertyNames.Iid] == "6c5aff74-f983-4aa8-a9d6-293b3429307c");
+            Assert.AreEqual(2, (int) parameter[PropertyNames.RevisionNumber]);
+            var expectedValueSets = new[] { (string) parameterValueSet[PropertyNames.Iid] };
+            valueSetsArray = (JArray) parameter[PropertyNames.ValueSet];
+            valueSets = valueSetsArray.Select(x => (string) x).ToList();
             CollectionAssert.AreEquivalent(expectedValueSets, valueSets);
-            Assert.AreEqual("db690d7d-761c-47fd-96d3-840d698a89dc", (string)parameter[PropertyNames.StateDependence]);
+            Assert.AreEqual("db690d7d-761c-47fd-96d3-840d698a89dc", (string) parameter[PropertyNames.StateDependence]);
+        }
+
+        [Test]
+        public void VerifyThatAStateDependentParameterCanBeUpdatedToAnotherStateDependentWithWebApi()
+        {
+            var iterationUri = new Uri(
+                string.Format(
+                    UriFormat,
+                    this.Settings.Hostname,
+                    "/EngineeringModel/9ec982e4-ef72-4953-aa85-b158a95d8d56/iteration/e163c5ad-f32b-4387-b805-f4b34600bc2c"));
+
+            var postBodyPath = this.GetPath(
+                "Tests/EngineeringModel/Parameter/PostUpdateParameterToStateDependent.json");
+
+            var postBody = this.GetJsonFromFile(postBodyPath);
+            var jArray = this.WebClient.PostDto(iterationUri, postBody);
+
+            var engineeeringModel = jArray.Single(
+                x => (string) x[PropertyNames.Iid] == "9ec982e4-ef72-4953-aa85-b158a95d8d56");
+
+            Assert.AreEqual(2, (int) engineeeringModel[PropertyNames.RevisionNumber]);
+
+            var parameterValueSet = jArray.Single(x => (string) x[PropertyNames.ClassKind] == "ParameterValueSet");
+            Assert.AreEqual(2, (int) parameterValueSet[PropertyNames.RevisionNumber]);
+
+            postBodyPath = this.GetPath(
+                "Tests/EngineeringModel/ActualFiniteStateList/PostNewActualFiniteStateList.json");
+
+            postBody = this.GetJsonFromFile(postBodyPath);
+            jArray = this.WebClient.PostDto(iterationUri, postBody);
+
+            engineeeringModel = jArray.Single(
+                x => (string) x[PropertyNames.Iid] == "9ec982e4-ef72-4953-aa85-b158a95d8d56");
+
+            Assert.AreEqual(3, (int) engineeeringModel[PropertyNames.RevisionNumber]);
+
+            var iteration = jArray.Single(x => (string) x[PropertyNames.Iid] == "e163c5ad-f32b-4387-b805-f4b34600bc2c");
+            Assert.AreEqual(3, (int) iteration[PropertyNames.RevisionNumber]);
+
+            postBodyPath = this.GetPath(
+                "Tests/EngineeringModel/Parameter/PostUpdateStateDependentParameterToAnotherState.json");
+
+            postBody = this.GetJsonFromFile(postBodyPath);
+            jArray = this.WebClient.PostDto(iterationUri, postBody);
+
+            engineeeringModel = jArray.Single(
+                x => (string) x[PropertyNames.Iid] == "9ec982e4-ef72-4953-aa85-b158a95d8d56");
+
+            Assert.AreEqual(4, (int) engineeeringModel[PropertyNames.RevisionNumber]);
+
+            parameterValueSet = jArray.Single(x => (string) x[PropertyNames.ClassKind] == "ParameterValueSet");
+            Assert.AreEqual(4, (int) parameterValueSet[PropertyNames.RevisionNumber]);
+
+            const string EmptyProperty = "[\"-\"]";
+            Assert.AreEqual("MANUAL", (string) parameterValueSet[PropertyNames.ValueSwitch]);
+            Assert.AreEqual(EmptyProperty, (string) parameterValueSet[PropertyNames.Published]);
+            Assert.AreEqual(EmptyProperty, (string) parameterValueSet[PropertyNames.Formula]);
+            Assert.AreEqual(EmptyProperty, (string) parameterValueSet[PropertyNames.Computed]);
+            Assert.AreEqual(EmptyProperty, (string) parameterValueSet[PropertyNames.Manual]);
+            Assert.AreEqual(EmptyProperty, (string) parameterValueSet[PropertyNames.Reference]);
+
+            var parameter = jArray.Single(x => (string) x[PropertyNames.ClassKind] == "Parameter");
+            Assert.AreEqual(4, (int) parameter[PropertyNames.RevisionNumber]);
+
+            var parameterSubscription = jArray.Single(x => (string) x[PropertyNames.ClassKind] == "ParameterSubscription");
+            Assert.AreEqual(4, (int) parameterSubscription[PropertyNames.RevisionNumber]);
+
+            var parameterOverride = jArray.Single(x => (string) x[PropertyNames.ClassKind] == "ParameterOverride");
+            Assert.AreEqual(4, (int) parameterOverride[PropertyNames.RevisionNumber]);
         }
 
         /// <summary>
@@ -584,65 +690,65 @@ namespace WebservicesIntegrationTests
         /// </param>
         public static void VerifyProperties(JToken parameter)
         {
-            if ((string)parameter[PropertyNames.Iid] == "6c5aff74-f983-4aa8-a9d6-293b3429307c")
+            if ((string) parameter[PropertyNames.Iid] == "6c5aff74-f983-4aa8-a9d6-293b3429307c")
             {
                 // verify the amount of returned properties 
                 Assert.AreEqual(14, parameter.Children().Count());
 
                 // assert that the properties are what is expected
-                Assert.AreEqual("6c5aff74-f983-4aa8-a9d6-293b3429307c", (string)parameter[PropertyNames.Iid]);
-                Assert.AreEqual(1, (int)parameter[PropertyNames.RevisionNumber]);
-                Assert.AreEqual("Parameter", (string)parameter[PropertyNames.ClassKind]);
+                Assert.AreEqual("6c5aff74-f983-4aa8-a9d6-293b3429307c", (string) parameter[PropertyNames.Iid]);
+                Assert.AreEqual(1, (int) parameter[PropertyNames.RevisionNumber]);
+                Assert.AreEqual("Parameter", (string) parameter[PropertyNames.ClassKind]);
 
-                Assert.IsNull((string)parameter[PropertyNames.RequestedBy]);
-                Assert.IsFalse((bool)parameter[PropertyNames.AllowDifferentOwnerOfOverride]);
-                Assert.IsFalse((bool)parameter[PropertyNames.ExpectsOverride]);
-                Assert.AreEqual("a21c15c4-3e1e-46b5-b109-5063dec1e254", (string)parameter[PropertyNames.ParameterType]);
-                Assert.IsNull((string)parameter[PropertyNames.Scale]);
-                Assert.IsNull((string)parameter[PropertyNames.StateDependence]);
-                Assert.AreEqual((string)parameter[PropertyNames.Group], "b739b3c6-9cc0-4e64-9cc4-ef7463edf559");
-                Assert.IsFalse((bool)parameter[PropertyNames.IsOptionDependent]);
-                Assert.AreEqual("0e92edde-fdff-41db-9b1d-f2e484f12535", (string)parameter[PropertyNames.Owner]);
+                Assert.IsNull((string) parameter[PropertyNames.RequestedBy]);
+                Assert.IsFalse((bool) parameter[PropertyNames.AllowDifferentOwnerOfOverride]);
+                Assert.IsFalse((bool) parameter[PropertyNames.ExpectsOverride]);
+                Assert.AreEqual("a21c15c4-3e1e-46b5-b109-5063dec1e254", (string) parameter[PropertyNames.ParameterType]);
+                Assert.IsNull((string) parameter[PropertyNames.Scale]);
+                Assert.IsNull((string) parameter[PropertyNames.StateDependence]);
+                Assert.AreEqual((string) parameter[PropertyNames.Group], "b739b3c6-9cc0-4e64-9cc4-ef7463edf559");
+                Assert.IsFalse((bool) parameter[PropertyNames.IsOptionDependent]);
+                Assert.AreEqual("0e92edde-fdff-41db-9b1d-f2e484f12535", (string) parameter[PropertyNames.Owner]);
 
                 var expectedValueSets = new[] { "af5c88c6-301f-497b-81f7-53748c3900ed" };
-                var valueSetsArray = (JArray)parameter[PropertyNames.ValueSet];
-                IList<string> valueSets = valueSetsArray.Select(x => (string)x).ToList();
+                var valueSetsArray = (JArray) parameter[PropertyNames.ValueSet];
+                IList<string> valueSets = valueSetsArray.Select(x => (string) x).ToList();
                 CollectionAssert.AreEquivalent(expectedValueSets, valueSets);
 
                 var expectedParameterSubscriptions = new[] { "f1f076c4-5307-42b8-a171-3263a9e7bb21" };
-                var parameterSubscriptionsArray = (JArray)parameter[PropertyNames.ParameterSubscription];
-                IList<string> parameterSubscriptions = parameterSubscriptionsArray.Select(x => (string)x).ToList();
+                var parameterSubscriptionsArray = (JArray) parameter[PropertyNames.ParameterSubscription];
+                IList<string> parameterSubscriptions = parameterSubscriptionsArray.Select(x => (string) x).ToList();
                 CollectionAssert.AreEquivalent(expectedParameterSubscriptions, parameterSubscriptions);
             }
 
-            if ((string)parameter[PropertyNames.Iid] == "3f05483f-66ff-4f21-bc76-45956779f66e")
+            if ((string) parameter[PropertyNames.Iid] == "3f05483f-66ff-4f21-bc76-45956779f66e")
             {
                 // verify the amount of returned properties 
                 Assert.AreEqual(14, parameter.Children().Count());
 
                 // assert that the properties are what is expected
-                Assert.AreEqual("3f05483f-66ff-4f21-bc76-45956779f66e", (string)parameter[PropertyNames.Iid]);
-                Assert.AreEqual(1, (int)parameter[PropertyNames.RevisionNumber]);
-                Assert.AreEqual("Parameter", (string)parameter[PropertyNames.ClassKind]);
+                Assert.AreEqual("3f05483f-66ff-4f21-bc76-45956779f66e", (string) parameter[PropertyNames.Iid]);
+                Assert.AreEqual(1, (int) parameter[PropertyNames.RevisionNumber]);
+                Assert.AreEqual("Parameter", (string) parameter[PropertyNames.ClassKind]);
 
-                Assert.IsNull((string)parameter[PropertyNames.RequestedBy]);
-                Assert.IsFalse((bool)parameter[PropertyNames.AllowDifferentOwnerOfOverride]);
-                Assert.IsFalse((bool)parameter[PropertyNames.ExpectsOverride]);
-                Assert.AreEqual("a21c15c4-3e1e-46b5-b109-5063dec1e254", (string)parameter[PropertyNames.ParameterType]);
-                Assert.IsNull((string)parameter[PropertyNames.Scale]);
-                Assert.IsNull((string)parameter[PropertyNames.StateDependence]);
-                Assert.AreEqual((string)parameter[PropertyNames.Group], "b739b3c6-9cc0-4e64-9cc4-ef7463edf559");
-                Assert.IsFalse((bool)parameter[PropertyNames.IsOptionDependent]);
-                Assert.AreEqual("eb759723-14b9-49f4-8611-544d037bb764", (string)parameter[PropertyNames.Owner]);
+                Assert.IsNull((string) parameter[PropertyNames.RequestedBy]);
+                Assert.IsFalse((bool) parameter[PropertyNames.AllowDifferentOwnerOfOverride]);
+                Assert.IsFalse((bool) parameter[PropertyNames.ExpectsOverride]);
+                Assert.AreEqual("a21c15c4-3e1e-46b5-b109-5063dec1e254", (string) parameter[PropertyNames.ParameterType]);
+                Assert.IsNull((string) parameter[PropertyNames.Scale]);
+                Assert.IsNull((string) parameter[PropertyNames.StateDependence]);
+                Assert.AreEqual((string) parameter[PropertyNames.Group], "b739b3c6-9cc0-4e64-9cc4-ef7463edf559");
+                Assert.IsFalse((bool) parameter[PropertyNames.IsOptionDependent]);
+                Assert.AreEqual("eb759723-14b9-49f4-8611-544d037bb764", (string) parameter[PropertyNames.Owner]);
 
                 var expectedValueSets = new[] { "72ec3701-bcb5-4bf6-bd78-30fd1b65e3be" };
-                var valueSetsArray = (JArray)parameter[PropertyNames.ValueSet];
-                IList<string> valueSets = valueSetsArray.Select(x => (string)x).ToList();
+                var valueSetsArray = (JArray) parameter[PropertyNames.ValueSet];
+                IList<string> valueSets = valueSetsArray.Select(x => (string) x).ToList();
                 CollectionAssert.AreEquivalent(expectedValueSets, valueSets);
 
                 var expectedParameterSubscriptions = new[] { "f1f076c4-5307-42b8-a171-3263a9e7bb21" };
-                var parameterSubscriptionsArray = (JArray)parameter[PropertyNames.ParameterSubscription];
-                IList<string> parameterSubscriptions = parameterSubscriptionsArray.Select(x => (string)x).ToList();
+                var parameterSubscriptionsArray = (JArray) parameter[PropertyNames.ParameterSubscription];
+                IList<string> parameterSubscriptions = parameterSubscriptionsArray.Select(x => (string) x).ToList();
                 CollectionAssert.AreEquivalent(expectedParameterSubscriptions, parameterSubscriptions);
             }
         }

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/Parameter/PostUpdateStateDependentParameterToAnotherState.json
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/Parameter/PostUpdateStateDependentParameterToAnotherState.json
@@ -1,0 +1,13 @@
+﻿{
+	"_delete": [],
+	"_create": [],
+	"_update": [
+		{
+			"classKind": "Parameter",
+			"iid": "6c5aff74-f983-4aa8-a9d6-293b3429307c",
+			"modifiedOn": "2017-04-15T14:59:59.802Z",
+			"stateDependence": "f4640b3f-7840-4cfc-9a15-80127f91c8db"
+		}
+	],
+	"_copy": []
+}

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/ParameterValueSet/ParameterValueSetTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/ParameterValueSet/ParameterValueSetTestFixture.cs
@@ -517,7 +517,7 @@ namespace WebservicesIntegrationTests
             postBody = postBody.Replace("<INNERJSON>", inputAsInnerJson);
 
             var jArray1 = this.WebClient.PostDto(iterationUri, postBody);
-            Assert.AreEqual(2, jArray1.Count);
+            Assert.AreEqual(3, jArray1.Count);
 
             var parameterValueSetUri1 =
                 new Uri(

--- a/IntegrationTestSuite/WebservicesIntegrationTests/WebservicesIntegrationTests.csproj
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/WebservicesIntegrationTests.csproj
@@ -121,7 +121,7 @@
     <Compile Include="Tests\SiteDirectory\EmailAddress\EmailAddressTestFixture.cs" />
     <Compile Include="Tests\SiteDirectory\EnumerationParameterType\EnumerationParameterTypeTestFixture.cs" />
     <Compile Include="Tests\SiteDirectory\IterationSetup\IterationSetupTestFixture.cs" />
-	<Compile Include="Tests\SiteDirectory\MeasurementScale\MeasurementScaleTestFixture.cs" />
+    <Compile Include="Tests\SiteDirectory\MeasurementScale\MeasurementScaleTestFixture.cs" />
     <Compile Include="Tests\SiteDirectory\ModelReferenceDataLibrary\ModelReferenceDataLibraryTestFixture.cs" />
     <Compile Include="Tests\SiteDirectory\Participant\ParticipantTestFixture.cs" />
     <Compile Include="Tests\SiteDirectory\PropertyNames.cs" />
@@ -284,6 +284,9 @@
     <None Include="Tests\EngineeringModel\Page\PostNewPages.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="Tests\EngineeringModel\Parameter\PostUpdateStateDependentParameterToAnotherState.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="Tests\EngineeringModel\ParametricConstraint\PostNewParametricConstraint.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
@@ -323,7 +326,7 @@
     <None Include="Tests\SiteDirectory\IterationSetup\PostUpdateCyclicIterationSetup.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-	<None Include="Tests\SiteDirectory\MeasurementScale\PostNewCyclicMappingToReferenceScale.json">
+    <None Include="Tests\SiteDirectory\MeasurementScale\PostNewCyclicMappingToReferenceScale.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="Tests\SiteDirectory\ParameterTypeComponent\PostReorderParameterTypeComponents.json">


### PR DESCRIPTION
Fix tests that fail due to wrong expectations now that ChangeLog is activated by default.