### PR TITLE
Refactor NUnit assertions to constraint-based syntax

### DIFF
--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/Iteration/IterationTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/Iteration/IterationTestFixture.cs
@@ -236,7 +236,7 @@ namespace WebservicesIntegrationTests
 
             var publicationsArray = (JArray)iteration[PropertyNames.Publication];
             IList<string> publications = publicationsArray.Select(x => (string)x).ToList();
-            CollectionAssert.IsEmpty(publications); // publication shoudl be empty
+            Assert.That(publications, Is.Empty); // publication should be empty
 
             var expectedPossibleFiniteStateLists = new string[]
             {
@@ -646,7 +646,7 @@ namespace WebservicesIntegrationTests
             var exception = Assert.Catch<WebException>(() => this.WebClient.PostDto(iterationUri, postBody));
             var errorMessage = this.WebClient.ExtractExceptionStringFromResponse(exception.Response);
             Assert.That(((HttpWebResponse)exception.Response).StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
-            Assert.That(errorMessage.Contains("The person Jane does not have an appropriate update permission for Iteration."), Is.True);
+            Assert.That(errorMessage, Does.Contain("The person Jane does not have an appropriate update permission for Iteration."));
         }
     }
 }

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/Parameter/ParameterTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/Parameter/ParameterTestFixture.cs
@@ -119,13 +119,13 @@ namespace WebservicesIntegrationTests
             Assert.That((string) parameter[PropertyNames.ClassKind], Is.EqualTo("Parameter"));
 
             Assert.That((string) parameter[PropertyNames.RequestedBy], Is.Null);
-            Assert.IsFalse((bool) parameter[PropertyNames.AllowDifferentOwnerOfOverride]);
-            Assert.IsFalse((bool) parameter[PropertyNames.ExpectsOverride]);
+            Assert.That((bool) parameter[PropertyNames.AllowDifferentOwnerOfOverride], Is.False);
+            Assert.That((bool) parameter[PropertyNames.ExpectsOverride], Is.False);
             Assert.That((string) parameter[PropertyNames.ParameterType], Is.EqualTo("35a9cf05-4eba-4cda-b60c-7cfeaac8f892"));
             Assert.That((string) parameter[PropertyNames.Scale], Is.Null);
             Assert.That((string) parameter[PropertyNames.StateDependence], Is.Null);
             Assert.That((string) parameter[PropertyNames.Group], Is.Null);
-            Assert.IsFalse((bool) parameter[PropertyNames.IsOptionDependent]);
+            Assert.That((bool) parameter[PropertyNames.IsOptionDependent], Is.False);
             Assert.That((string) parameter[PropertyNames.Owner], Is.EqualTo("0e92edde-fdff-41db-9b1d-f2e484f12535"));
 
             var expectedParameterSubscriptions = new string[] { };
@@ -272,13 +272,13 @@ namespace WebservicesIntegrationTests
             Assert.That((string) parameter[PropertyNames.ClassKind], Is.EqualTo("Parameter"));
 
             Assert.That((string) parameter[PropertyNames.RequestedBy], Is.Null);
-            Assert.IsFalse((bool) parameter[PropertyNames.AllowDifferentOwnerOfOverride]);
-            Assert.IsFalse((bool) parameter[PropertyNames.ExpectsOverride]);
+            Assert.That((bool) parameter[PropertyNames.AllowDifferentOwnerOfOverride], Is.False);
+            Assert.That((bool) parameter[PropertyNames.ExpectsOverride], Is.False);
             Assert.That((string) parameter[PropertyNames.ParameterType], Is.EqualTo("35a9cf05-4eba-4cda-b60c-7cfeaac8f892"));
             Assert.That((string) parameter[PropertyNames.Scale], Is.Null);
             Assert.That((string) parameter[PropertyNames.StateDependence], Is.Null);
             Assert.That((string) parameter[PropertyNames.Group], Is.Null);
-            Assert.IsFalse((bool) parameter[PropertyNames.IsOptionDependent]);
+            Assert.That((bool) parameter[PropertyNames.IsOptionDependent], Is.False);
             Assert.That((string) parameter[PropertyNames.Owner], Is.EqualTo("0e92edde-fdff-41db-9b1d-f2e484f12535"));
 
             var expectedParameterSubscriptions = new string[] { };
@@ -357,13 +357,13 @@ namespace WebservicesIntegrationTests
             Assert.That((string) parameter[PropertyNames.ClassKind], Is.EqualTo("Parameter"));
 
             Assert.That((string) parameter[PropertyNames.RequestedBy], Is.Null);
-            Assert.IsFalse((bool) parameter[PropertyNames.AllowDifferentOwnerOfOverride]);
-            Assert.IsFalse((bool) parameter[PropertyNames.ExpectsOverride]);
+            Assert.That((bool) parameter[PropertyNames.AllowDifferentOwnerOfOverride], Is.False);
+            Assert.That((bool) parameter[PropertyNames.ExpectsOverride], Is.False);
             Assert.That((string) parameter[PropertyNames.ParameterType], Is.EqualTo("4a783624-b2bc-4e6d-95b3-11d036f6e917"));
             Assert.That((string) parameter[PropertyNames.Scale], Is.Null);
             Assert.That((string) parameter[PropertyNames.StateDependence], Is.Null);
             Assert.That((string) parameter[PropertyNames.Group], Is.Null);
-            Assert.IsFalse((bool) parameter[PropertyNames.IsOptionDependent]);
+            Assert.That((bool) parameter[PropertyNames.IsOptionDependent], Is.False);
             Assert.That((string) parameter[PropertyNames.Owner], Is.EqualTo("0e92edde-fdff-41db-9b1d-f2e484f12535"));
 
             var expectedParameterSubscriptions = new string[] { };
@@ -441,13 +441,13 @@ namespace WebservicesIntegrationTests
             Assert.That((string) parameter[PropertyNames.ClassKind], Is.EqualTo("Parameter"));
 
             Assert.That((string) parameter[PropertyNames.RequestedBy], Is.Null);
-            Assert.IsFalse((bool) parameter[PropertyNames.AllowDifferentOwnerOfOverride]);
-            Assert.IsFalse((bool) parameter[PropertyNames.ExpectsOverride]);
+            Assert.That((bool) parameter[PropertyNames.AllowDifferentOwnerOfOverride], Is.False);
+            Assert.That((bool) parameter[PropertyNames.ExpectsOverride], Is.False);
             Assert.That((string) parameter[PropertyNames.ParameterType], Is.EqualTo("35a9cf05-4eba-4cda-b60c-7cfeaac8f892"));
             Assert.That((string) parameter[PropertyNames.Scale], Is.Null);
             Assert.That((string) parameter[PropertyNames.StateDependence], Is.Null);
             Assert.That((string) parameter[PropertyNames.Group], Is.Null);
-            Assert.IsTrue((bool) parameter[PropertyNames.IsOptionDependent]);
+            Assert.That((bool) parameter[PropertyNames.IsOptionDependent], Is.True);
             Assert.That((string) parameter[PropertyNames.Owner], Is.EqualTo("0e92edde-fdff-41db-9b1d-f2e484f12535"));
 
             var expectedParameterSubscriptions = new string[] { };
@@ -708,13 +708,13 @@ namespace WebservicesIntegrationTests
                 Assert.That((string) parameter[PropertyNames.ClassKind], Is.EqualTo("Parameter"));
 
                 Assert.That((string) parameter[PropertyNames.RequestedBy], Is.Null);
-                Assert.IsFalse((bool) parameter[PropertyNames.AllowDifferentOwnerOfOverride]);
-                Assert.IsFalse((bool) parameter[PropertyNames.ExpectsOverride]);
+                Assert.That((bool) parameter[PropertyNames.AllowDifferentOwnerOfOverride], Is.False);
+                Assert.That((bool) parameter[PropertyNames.ExpectsOverride], Is.False);
                 Assert.That((string) parameter[PropertyNames.ParameterType], Is.EqualTo("a21c15c4-3e1e-46b5-b109-5063dec1e254"));
                 Assert.That((string) parameter[PropertyNames.Scale], Is.Null);
                 Assert.That((string) parameter[PropertyNames.StateDependence], Is.Null);
                 Assert.That("b739b3c6-9cc0-4e64-9cc4-ef7463edf559", Is.EqualTo((string) parameter[PropertyNames.Group]));
-                Assert.IsFalse((bool) parameter[PropertyNames.IsOptionDependent]);
+                Assert.That((bool) parameter[PropertyNames.IsOptionDependent], Is.False);
                 Assert.That((string) parameter[PropertyNames.Owner], Is.EqualTo("0e92edde-fdff-41db-9b1d-f2e484f12535"));
 
                 var expectedValueSets = new[] { "af5c88c6-301f-497b-81f7-53748c3900ed" };
@@ -739,13 +739,13 @@ namespace WebservicesIntegrationTests
                 Assert.That((string) parameter[PropertyNames.ClassKind], Is.EqualTo("Parameter"));
 
                 Assert.That((string) parameter[PropertyNames.RequestedBy], Is.Null);
-                Assert.IsFalse((bool) parameter[PropertyNames.AllowDifferentOwnerOfOverride]);
-                Assert.IsFalse((bool) parameter[PropertyNames.ExpectsOverride]);
+                Assert.That((bool) parameter[PropertyNames.AllowDifferentOwnerOfOverride], Is.False);
+                Assert.That((bool) parameter[PropertyNames.ExpectsOverride], Is.False);
                 Assert.That((string) parameter[PropertyNames.ParameterType], Is.EqualTo("a21c15c4-3e1e-46b5-b109-5063dec1e254"));
                 Assert.That((string) parameter[PropertyNames.Scale], Is.Null);
                 Assert.That((string) parameter[PropertyNames.StateDependence], Is.Null);
                 Assert.That("b739b3c6-9cc0-4e64-9cc4-ef7463edf559", Is.EqualTo((string) parameter[PropertyNames.Group]));
-                Assert.IsFalse((bool) parameter[PropertyNames.IsOptionDependent]);
+                Assert.That((bool) parameter[PropertyNames.IsOptionDependent], Is.False);
                 Assert.That((string) parameter[PropertyNames.Owner], Is.EqualTo("eb759723-14b9-49f4-8611-544d037bb764"));
 
                 var expectedValueSets = new[] { "72ec3701-bcb5-4bf6-bd78-30fd1b65e3be" };

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/ParameterValueSet/ParameterValueSetTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/ParameterValueSet/ParameterValueSetTestFixture.cs
@@ -183,7 +183,9 @@ namespace WebservicesIntegrationTests
                 expectedPossibleStates.Remove(possibleState);
             }
 
-            CollectionAssert.IsEmpty(expectedPossibleStates, 
+            Assert.That(
+                expectedPossibleStates,
+                Is.Empty,
                 "There still are expected possible states in the collection. " +
                 "The ones that are still present there have not been found in the result set where they should have.");
 
@@ -253,7 +255,9 @@ namespace WebservicesIntegrationTests
                 Assert.That((string)parameterValueSet[PropertyNames.ActualOption], Is.Null);
             }
 
-            CollectionAssert.IsEmpty(actualStatesCheckList,
+            Assert.That(
+                actualStatesCheckList,
+                Is.Empty,
                 "There still are expected actual states in the collection. " +
                 "The ones that are still present there have not been found in the result set where they should have.");
 

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/Requirement/RequirementTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/Requirement/RequirementTestFixture.cs
@@ -107,7 +107,7 @@ namespace WebservicesIntegrationTests
             Assert.That((int) requirement[PropertyNames.RevisionNumber], Is.EqualTo(2));
             Assert.That((string) requirement[PropertyNames.Name], Is.EqualTo("create requirement"));
             Assert.That((string) requirement[PropertyNames.ShortName], Is.EqualTo("createrequirement"));
-            Assert.IsFalse((bool) requirement[PropertyNames.IsDeprecated]);
+            Assert.That((bool) requirement[PropertyNames.IsDeprecated], Is.False);
         }
 
         [Test]
@@ -204,7 +204,7 @@ namespace WebservicesIntegrationTests
 
             Assert.That((string) requirement[PropertyNames.Owner], Is.EqualTo("0e92edde-fdff-41db-9b1d-f2e484f12535"));
 
-            Assert.IsFalse((bool) requirement[PropertyNames.IsDeprecated]);
+            Assert.That((bool) requirement[PropertyNames.IsDeprecated], Is.False);
             Assert.That((string) requirement[PropertyNames.Group], Is.Null);
 
             var expectedCategories = new[] { "167b5cb0-766e-4ab2-b728-a9c9a662b017" };
@@ -264,7 +264,7 @@ namespace WebservicesIntegrationTests
 
                 Assert.That((string) requirement[PropertyNames.Owner], Is.EqualTo("0e92edde-fdff-41db-9b1d-f2e484f12535"));
 
-                Assert.IsFalse((bool) requirement[PropertyNames.IsDeprecated]);
+                Assert.That((bool) requirement[PropertyNames.IsDeprecated], Is.False);
                 Assert.That((string) requirement[PropertyNames.Group], Is.EqualTo("d3474e6a-f9ac-4d1a-91d9-6f8be06a03b5"));
 
                 expectedCategories = new string[] { };
@@ -327,7 +327,7 @@ namespace WebservicesIntegrationTests
             var exception = Assert.Catch<WebException>(() => this.WebClient.PostDto(iterationUri, postBody));
             var errorMessage = this.WebClient.ExtractExceptionStringFromResponse(exception.Response);
             Assert.That(((HttpWebResponse) exception.Response).StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
-            Assert.IsTrue(errorMessage.Contains("The person Jane does not have an appropriate update permission for Definition."));
+            Assert.That(errorMessage, Does.Contain("The person Jane does not have an appropriate update permission for Definition."));
         }
     }
 }

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/RequirementsSpecification/RequirementsSpecificationTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/RequirementsSpecification/RequirementsSpecificationTestFixture.cs
@@ -114,7 +114,7 @@ namespace WebservicesIntegrationTests
 
             Assert.That((string)requirementsSpecification[PropertyNames.Owner], Is.EqualTo("0e92edde-fdff-41db-9b1d-f2e484f12535"));
 
-            Assert.IsFalse((bool)requirementsSpecification[PropertyNames.IsDeprecated]);
+            Assert.That((bool)requirementsSpecification[PropertyNames.IsDeprecated], Is.False);
 
             var expectedAliases = new string[] { };
             var aliasesArray = (JArray)requirementsSpecification[PropertyNames.Alias];
@@ -157,7 +157,7 @@ namespace WebservicesIntegrationTests
 
             Assert.That((string)requirementsSpecification[PropertyNames.Owner], Is.EqualTo("0e92edde-fdff-41db-9b1d-f2e484f12535"));
 
-            Assert.IsFalse((bool)requirementsSpecification[PropertyNames.IsDeprecated]);
+            Assert.That((bool)requirementsSpecification[PropertyNames.IsDeprecated], Is.False);
 
             var expectedAliases = new string[] { };
             var aliasesArray = (JArray)requirementsSpecification[PropertyNames.Alias];

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/RuleVerification/RuleVerificationTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/RuleVerification/RuleVerificationTestFixture.cs
@@ -124,7 +124,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) builtInRuleVerification[PropertyNames.Name], Is.EqualTo("Test Built In Rule Verification"));
             Assert.That((string) builtInRuleVerification[PropertyNames.Status], Is.EqualTo("NONE"));
             Assert.That((string) builtInRuleVerification[PropertyNames.ExecutedOn], Is.Null);
-            Assert.IsFalse((bool) builtInRuleVerification[PropertyNames.IsActive]);
+            Assert.That((bool) builtInRuleVerification[PropertyNames.IsActive], Is.False);
 
             // get a specific RuleVerification from the result by it's unique id
             var userRuleVerification = jArray.Single(x => (string) x[PropertyNames.Iid] == "486f4b97-fcb1-409e-b5c0-057c240f41b6");
@@ -138,7 +138,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) userRuleVerification[PropertyNames.ClassKind], Is.EqualTo("UserRuleVerification"));
             Assert.That((string) userRuleVerification[PropertyNames.Status], Is.EqualTo("NONE"));
             Assert.That((string) userRuleVerification[PropertyNames.ExecutedOn], Is.Null);
-            Assert.IsFalse((bool) userRuleVerification[PropertyNames.IsActive]);
+            Assert.That((bool) userRuleVerification[PropertyNames.IsActive], Is.False);
             Assert.That((string) userRuleVerification[PropertyNames.Rule], Is.EqualTo("8a5cd66e-7313-4843-813f-37081ca81bb8"));
         }
 

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/UserRuleVerification/UserRuleVerificationTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/UserRuleVerification/UserRuleVerificationTestFixture.cs
@@ -90,7 +90,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) userRuleVerification[PropertyNames.ClassKind], Is.EqualTo("UserRuleVerification"));
             Assert.That((string) userRuleVerification[PropertyNames.Status], Is.EqualTo("PASSED"));
             Assert.That((string) userRuleVerification[PropertyNames.ExecutedOn], Is.Null);
-            Assert.IsTrue((bool) userRuleVerification[PropertyNames.IsActive]);
+            Assert.That((bool) userRuleVerification[PropertyNames.IsActive], Is.True);
             Assert.That((string) userRuleVerification[PropertyNames.Rule], Is.EqualTo("8a5cd66e-7313-4843-813f-37081ca81bb8"));
         }
     }

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/ArrayParameterType/ArrayParameterTypeTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/ArrayParameterType/ArrayParameterTypeTestFixture.cs
@@ -173,12 +173,12 @@ namespace WebservicesIntegrationTests
             Assert.That((int)arrayParameterType[PropertyNames.RevisionNumber], Is.EqualTo(1));
             Assert.That((string)arrayParameterType[PropertyNames.ClassKind], Is.EqualTo("ArrayParameterType"));
 
-            Assert.IsFalse((bool) arrayParameterType[PropertyNames.IsDeprecated]);
+            Assert.That((bool) arrayParameterType[PropertyNames.IsDeprecated], Is.False);
             Assert.That((string)arrayParameterType[PropertyNames.Name], Is.EqualTo("Test Array ParameterType"));
             Assert.That((string)arrayParameterType[PropertyNames.ShortName], Is.EqualTo("TestArrayParameterType"));
 
             Assert.That((string)arrayParameterType[PropertyNames.Symbol], Is.EqualTo("testarray"));
-            Assert.IsFalse((bool) arrayParameterType[PropertyNames.IsFinalized]);
+            Assert.That((bool) arrayParameterType[PropertyNames.IsFinalized], Is.False);
 
             var expectedComponents = new List<OrderedItem>
             {
@@ -191,7 +191,7 @@ namespace WebservicesIntegrationTests
 
             Assert.That(componentsArray, Is.EquivalentTo(expectedComponents));
 
-            Assert.IsFalse((bool) arrayParameterType[PropertyNames.IsTensor]);
+            Assert.That((bool) arrayParameterType[PropertyNames.IsTensor], Is.False);
 
             var expectedDimensions = new List<OrderedItem>
             {

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/BinaryRelationshipRule/BinaryRelationshipRuleTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/BinaryRelationshipRule/BinaryRelationshipRuleTestFixture.cs
@@ -93,7 +93,7 @@ namespace WebservicesIntegrationTests
             Assert.That((int)binaryRelationshipRule["revisionNumber"], Is.EqualTo(1));
             Assert.That((string)binaryRelationshipRule["classKind"], Is.EqualTo("BinaryRelationshipRule"));
 
-            Assert.IsFalse((bool) binaryRelationshipRule["isDeprecated"]);
+            Assert.That((bool) binaryRelationshipRule["isDeprecated"], Is.False);
             Assert.That((string)binaryRelationshipRule["name"], Is.EqualTo("Test Binary Relationship Rule"));
             Assert.That((string)binaryRelationshipRule["shortName"], Is.EqualTo("TestBinaryRelationshipRule"));
 

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/BooleanParameterType/BooleanParameterTypeTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/BooleanParameterType/BooleanParameterTypeTestFixture.cs
@@ -93,7 +93,7 @@ namespace WebservicesIntegrationTests
             Assert.That((int)booleanParameterType[PropertyNames.RevisionNumber], Is.EqualTo(1));
             Assert.That((string)booleanParameterType[PropertyNames.ClassKind], Is.EqualTo("BooleanParameterType"));
 
-            Assert.IsFalse((bool) booleanParameterType[PropertyNames.IsDeprecated]);
+            Assert.That((bool) booleanParameterType[PropertyNames.IsDeprecated], Is.False);
             Assert.That((string)booleanParameterType[PropertyNames.Name], Is.EqualTo("Test Boolean ParameterType"));
             Assert.That((string)booleanParameterType[PropertyNames.ShortName], Is.EqualTo("TestBooleanParameterType"));
 

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/Category/CategoryTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/Category/CategoryTestFixture.cs
@@ -410,7 +410,7 @@ namespace WebservicesIntegrationTests
             IList<string> rulesList = rulesArray.Select(x => (string)x).ToList();
             Assert.That(rulesList, Is.EquivalentTo(expectedRules));
 
-            Assert.IsEmpty(siteReferenceDataLibrary["requiredRdl"]);
+            Assert.That(siteReferenceDataLibrary["requiredRdl"], Is.Empty);
 
             var expectedConstants = new string[]
             {

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/Constant/ConstantTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/Constant/ConstantTestFixture.cs
@@ -168,7 +168,7 @@ namespace WebservicesIntegrationTests
             Assert.That((int)siteReferenceDataLibrary[PropertyNames.RevisionNumber], Is.EqualTo(2));
             Assert.That((string)siteReferenceDataLibrary[PropertyNames.ClassKind], Is.EqualTo("SiteReferenceDataLibrary"));
 
-            Assert.IsFalse((bool)siteReferenceDataLibrary[PropertyNames.IsDeprecated]);
+            Assert.That((bool)siteReferenceDataLibrary[PropertyNames.IsDeprecated], Is.False);
             Assert.That((string)siteReferenceDataLibrary[PropertyNames.Name], Is.EqualTo("Test Reference Data Library"));
             Assert.That((string)siteReferenceDataLibrary[PropertyNames.ShortName], Is.EqualTo("TestRDL"));
 
@@ -300,7 +300,7 @@ namespace WebservicesIntegrationTests
             IList<string> rulesList = rulesArray.Select(x => (string)x).ToList();
             Assert.That(rulesList, Is.EquivalentTo(expectedRules));
 
-            Assert.IsEmpty(siteReferenceDataLibrary["requiredRdl"]);
+            Assert.That(siteReferenceDataLibrary["requiredRdl"], Is.Empty);
 
             var expectedConstants = new string[]
             {
@@ -322,7 +322,7 @@ namespace WebservicesIntegrationTests
             Assert.That((int)constant[PropertyNames.RevisionNumber], Is.EqualTo(2));
             Assert.That((string)constant[PropertyNames.ClassKind], Is.EqualTo("Constant"));
 
-            Assert.IsFalse((bool)constant[PropertyNames.IsDeprecated]);
+            Assert.That((bool)constant[PropertyNames.IsDeprecated], Is.False);
             Assert.That((string)constant[PropertyNames.Name], Is.EqualTo("New Constant"));
             Assert.That((string)constant[PropertyNames.ShortName], Is.EqualTo("NewConstant"));
 
@@ -370,7 +370,7 @@ namespace WebservicesIntegrationTests
             Assert.That((int)constant[PropertyNames.RevisionNumber], Is.EqualTo(1));
             Assert.That((string)constant[PropertyNames.ClassKind], Is.EqualTo("Constant"));
 
-            Assert.IsFalse((bool) constant[PropertyNames.IsDeprecated]);
+            Assert.That((bool) constant[PropertyNames.IsDeprecated], Is.False);
             Assert.That((string)constant[PropertyNames.Name], Is.EqualTo("Test Constant"));
             Assert.That((string)constant[PropertyNames.ShortName], Is.EqualTo("TestConstant"));
 

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/CyclicRatioScale/CyclicRatioScaleTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/CyclicRatioScale/CyclicRatioScaleTestFixture.cs
@@ -169,7 +169,7 @@ namespace WebservicesIntegrationTests
             Assert.That((int)siteReferenceDataLibrary[PropertyNames.RevisionNumber], Is.EqualTo(2));
             Assert.That((string)siteReferenceDataLibrary[PropertyNames.ClassKind], Is.EqualTo("SiteReferenceDataLibrary"));
 
-            Assert.IsFalse((bool)siteReferenceDataLibrary[PropertyNames.IsDeprecated]);
+            Assert.That((bool)siteReferenceDataLibrary[PropertyNames.IsDeprecated], Is.False);
             Assert.That((string)siteReferenceDataLibrary[PropertyNames.Name], Is.EqualTo("Test Reference Data Library"));
             Assert.That((string)siteReferenceDataLibrary[PropertyNames.ShortName], Is.EqualTo("TestRDL"));
 
@@ -302,7 +302,7 @@ namespace WebservicesIntegrationTests
             IList<string> rulesList = rulesArray.Select(x => (string)x).ToList();
             Assert.That(rulesList, Is.EquivalentTo(expectedRules));
 
-            Assert.IsEmpty(siteReferenceDataLibrary["requiredRdl"]);
+            Assert.That(siteReferenceDataLibrary["requiredRdl"], Is.Empty);
 
             var expectedConstants = new string[]
             {
@@ -325,7 +325,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string)cyclicRatioScale["name"], Is.EqualTo("New CyclicRatioScale"));
             Assert.That((string)cyclicRatioScale["shortName"], Is.EqualTo("NewCyclic"));
 
-            Assert.IsFalse((bool)cyclicRatioScale["isDeprecated"]);
+            Assert.That((bool)cyclicRatioScale["isDeprecated"], Is.False);
             Assert.That((string)cyclicRatioScale["modulus"], Is.EqualTo("360"));
             Assert.That((string)cyclicRatioScale["unit"], Is.EqualTo("56842970-3915-4369-8712-61cfd8273ef9"));
 
@@ -336,9 +336,9 @@ namespace WebservicesIntegrationTests
 
             Assert.That((string)cyclicRatioScale["numberSet"], Is.EqualTo("NATURAL_NUMBER_SET"));
             Assert.That((string)cyclicRatioScale["minimumPermissibleValue"], Is.EqualTo("0"));
-            Assert.IsTrue((bool)cyclicRatioScale["isMinimumInclusive"]);
+            Assert.That((bool)cyclicRatioScale["isMinimumInclusive"], Is.True);
             Assert.That((string)cyclicRatioScale["maximumPermissibleValue"], Is.EqualTo("360"));
-            Assert.IsTrue((bool)cyclicRatioScale["isMaximumInclusive"]);
+            Assert.That((bool)cyclicRatioScale["isMaximumInclusive"], Is.True);
             Assert.That((string)cyclicRatioScale["positiveValueConnotation"], Is.EqualTo(""));
             Assert.That((string)cyclicRatioScale["negativeValueConnotation"], Is.EqualTo(""));
 
@@ -383,7 +383,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string)cyclicRatioScale["name"], Is.EqualTo("Test Cyclic Ratio Scale"));
             Assert.That((string)cyclicRatioScale["shortName"], Is.EqualTo("TestCyclicRatioScale"));
 
-            Assert.IsFalse((bool) cyclicRatioScale["isDeprecated"]);
+            Assert.That((bool) cyclicRatioScale["isDeprecated"], Is.False);
             Assert.That((string)cyclicRatioScale["modulus"], Is.EqualTo("360"));
             Assert.That((string)cyclicRatioScale["unit"], Is.EqualTo("56842970-3915-4369-8712-61cfd8273ef9"));
 
@@ -394,9 +394,9 @@ namespace WebservicesIntegrationTests
 
             Assert.That((string)cyclicRatioScale["numberSet"], Is.EqualTo("NATURAL_NUMBER_SET"));
             Assert.That((string)cyclicRatioScale["minimumPermissibleValue"], Is.EqualTo("0"));
-            Assert.IsTrue((bool) cyclicRatioScale["isMinimumInclusive"]);
+            Assert.That((bool) cyclicRatioScale["isMinimumInclusive"], Is.True);
             Assert.That((string)cyclicRatioScale["maximumPermissibleValue"], Is.EqualTo("360"));
-            Assert.IsTrue((bool) cyclicRatioScale["isMaximumInclusive"]);
+            Assert.That((bool) cyclicRatioScale["isMaximumInclusive"], Is.True);
             Assert.That((string) cyclicRatioScale["positiveValueConnotation"], Is.Null);
             Assert.That((string)cyclicRatioScale["negativeValueConnotation"], Is.EqualTo(""));
             

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/Definition/DefinitionTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/Definition/DefinitionTestFixture.cs
@@ -126,7 +126,7 @@ namespace WebservicesIntegrationTests
             Assert.That((int)siteReferenceDataLibrary["revisionNumber"], Is.EqualTo(2));
             Assert.That((string)siteReferenceDataLibrary["classKind"], Is.EqualTo("SiteReferenceDataLibrary"));
 
-            Assert.IsFalse((bool) siteReferenceDataLibrary["isDeprecated"]);
+            Assert.That((bool) siteReferenceDataLibrary["isDeprecated"], Is.False);
             Assert.That((string)siteReferenceDataLibrary["name"], Is.EqualTo("Test Reference Data Library"));
             Assert.That((string)siteReferenceDataLibrary["shortName"], Is.EqualTo("TestRDL"));
 
@@ -270,7 +270,7 @@ namespace WebservicesIntegrationTests
             IList<string> rulesList = rulesArray.Select(x => (string) x).ToList();
             Assert.That(rulesList, Is.EquivalentTo(expectedRules));
 
-            Assert.IsEmpty(siteReferenceDataLibrary["requiredRdl"]);
+            Assert.That(siteReferenceDataLibrary["requiredRdl"], Is.Empty);
 
             var expectedConstants = new string[]
             {

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/DerivedQuantityKind/DerivedQuantityKindTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/DerivedQuantityKind/DerivedQuantityKindTestFixture.cs
@@ -108,7 +108,7 @@ namespace WebservicesIntegrationTests
             Assert.That((int)derivedQuantityKind[PropertyNames.RevisionNumber], Is.EqualTo(1));
             Assert.That((string)derivedQuantityKind[PropertyNames.ClassKind], Is.EqualTo("DerivedQuantityKind"));
 
-            Assert.IsFalse((bool) derivedQuantityKind[PropertyNames.IsDeprecated]);
+            Assert.That((bool) derivedQuantityKind[PropertyNames.IsDeprecated], Is.False);
             Assert.That((string)derivedQuantityKind[PropertyNames.Name], Is.EqualTo("Test Derived QuantityKind"));
             Assert.That((string)derivedQuantityKind[PropertyNames.ShortName], Is.EqualTo("TestDerivedQuantityKind"));
 

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/DerivedUnit/DerivedUnitTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/DerivedUnit/DerivedUnitTestFixture.cs
@@ -93,7 +93,7 @@ namespace WebservicesIntegrationTests
             Assert.That((int)derivedUnit["revisionNumber"], Is.EqualTo(1));
             Assert.That((string)derivedUnit["classKind"], Is.EqualTo("DerivedUnit"));
 
-            Assert.IsFalse((bool) derivedUnit["isDeprecated"]);
+            Assert.That((bool) derivedUnit["isDeprecated"], Is.False);
             Assert.That((string)derivedUnit["name"], Is.EqualTo("Test Derived Unit"));
             Assert.That((string)derivedUnit["shortName"], Is.EqualTo("TestDerivedUnit"));
 

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/DomainOfExpertise/DomainOfExpertiseTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/DomainOfExpertise/DomainOfExpertiseTestFixture.cs
@@ -96,7 +96,7 @@ namespace WebservicesIntegrationTests
             var exception = Assert.Catch<WebException>(() => this.WebClient.PostDto(siteDirectoryUri, postBody));
             var errorMessage = this.WebClient.ExtractExceptionStringFromResponse(exception.Response);
             Assert.That(((HttpWebResponse)exception.Response).StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
-            Assert.IsTrue(errorMessage.Contains("The person Jane does not have an appropriate update permission for DomainOfExpertise."));
+            Assert.That(errorMessage, Does.Contain("The person Jane does not have an appropriate update permission for DomainOfExpertise."));
         }
 
         [Test]
@@ -247,7 +247,7 @@ namespace WebservicesIntegrationTests
                 // assert that the properties are what is expected
                 Assert.That((string)domainOfExpertise["name"], Is.EqualTo("Test Domain of Expertise"));
                 Assert.That((string)domainOfExpertise["shortName"], Is.EqualTo("TST"));
-                Assert.IsFalse((bool)domainOfExpertise["isDeprecated"]);
+                Assert.That((bool)domainOfExpertise["isDeprecated"], Is.False);
 
                 var expectedAliases = new string[] { };
                 var aliasesArray = (JArray)domainOfExpertise["alias"];
@@ -279,7 +279,7 @@ namespace WebservicesIntegrationTests
                 // assert that the properties are what is expected
                 Assert.That((string)domainOfExpertise["name"], Is.EqualTo("Additional Test Domain of Expertise"));
                 Assert.That((string)domainOfExpertise["shortName"], Is.EqualTo("ADD"));
-                Assert.IsFalse((bool)domainOfExpertise["isDeprecated"]);
+                Assert.That((bool)domainOfExpertise["isDeprecated"], Is.False);
 
                 var expectedAliases = new string[] { };
                 var aliasesArray = (JArray)domainOfExpertise["alias"];

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/DomainOfExpertiseGroup/DomainOfExpertiseGroupTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/DomainOfExpertiseGroup/DomainOfExpertiseGroupTestFixture.cs
@@ -88,7 +88,7 @@ namespace WebservicesIntegrationTests
             // assert that the properties are what is expected
             Assert.That((string)domainOfExpertiseGroup[PropertyNames.Name], Is.EqualTo("Test Domain Of ExpertiseGroup"));
             Assert.That((string)domainOfExpertiseGroup[PropertyNames.ShortName], Is.EqualTo("TestDomainOfExpertiseGroup"));
-            Assert.IsFalse((bool)domainOfExpertiseGroup[PropertyNames.IsDeprecated]);
+            Assert.That((bool)domainOfExpertiseGroup[PropertyNames.IsDeprecated], Is.False);
 
             var expectedAliases = new string[] { };
             var aliasesArray = (JArray)domainOfExpertiseGroup[PropertyNames.Alias];

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/EngineeringModelSetup/EngineeringModelSetupTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/EngineeringModelSetup/EngineeringModelSetupTestFixture.cs
@@ -72,7 +72,7 @@ namespace WebservicesIntegrationTests
                 Assert.That((string)engineeringModelSetup[PropertyNames.Kind], Is.EqualTo("STUDY_MODEL"));
                 Assert.That((string)engineeringModelSetup[PropertyNames.StudyPhase], Is.EqualTo("PREPARATION_PHASE"));
                 Assert.That((string)engineeringModelSetup[PropertyNames.ClassKind], Is.EqualTo("EngineeringModelSetup"));
-                Assert.IsEmpty(engineeringModelSetup[PropertyNames.SourceEngineeringModelSetupIid]);
+                Assert.That(engineeringModelSetup[PropertyNames.SourceEngineeringModelSetupIid], Is.Empty);
             });
 
             var expectedAliases = new string[] { };

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/EnumerationParameterType/EnumerationParameterTypeTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/EnumerationParameterType/EnumerationParameterTypeTestFixture.cs
@@ -173,7 +173,7 @@ namespace WebservicesIntegrationTests
             Assert.That((int)siteReferenceDataLibrary[PropertyNames.RevisionNumber], Is.EqualTo(2));
             Assert.That((string)siteReferenceDataLibrary[PropertyNames.ClassKind], Is.EqualTo("SiteReferenceDataLibrary"));
 
-            Assert.IsFalse((bool) siteReferenceDataLibrary[PropertyNames.IsDeprecated]);
+            Assert.That((bool) siteReferenceDataLibrary[PropertyNames.IsDeprecated], Is.False);
             Assert.That((string)siteReferenceDataLibrary[PropertyNames.Name], Is.EqualTo("Test Reference Data Library"));
             Assert.That((string)siteReferenceDataLibrary[PropertyNames.ShortName], Is.EqualTo("TestRDL"));
 
@@ -318,7 +318,7 @@ namespace WebservicesIntegrationTests
             IList<string> rulesList = rulesArray.Select(x => (string) x).ToList();
             Assert.That(rulesList, Is.EquivalentTo(expectedRules));
 
-            Assert.IsEmpty(siteReferenceDataLibrary["requiredRdl"]);
+            Assert.That(siteReferenceDataLibrary["requiredRdl"], Is.Empty);
 
             var expectedConstants = new string[]
             {
@@ -341,11 +341,11 @@ namespace WebservicesIntegrationTests
             Assert.That((int)enumerationParameterType["revisionNumber"], Is.EqualTo(2));
             Assert.That((string)enumerationParameterType["classKind"], Is.EqualTo("EnumerationParameterType"));
 
-            Assert.IsFalse((bool) enumerationParameterType["isDeprecated"]);
+            Assert.That((bool) enumerationParameterType["isDeprecated"], Is.False);
             Assert.That((string)enumerationParameterType["name"], Is.EqualTo("Test Enumeration ParameterType"));
             Assert.That((string)enumerationParameterType["shortName"], Is.EqualTo("TestEnumerationParameterType"));
 
-            Assert.IsFalse((bool) enumerationParameterType["allowMultiSelect"]);
+            Assert.That((bool) enumerationParameterType["allowMultiSelect"], Is.False);
 
             var expectedValueDefinitions = new List<OrderedItem>
             {
@@ -463,11 +463,11 @@ namespace WebservicesIntegrationTests
             Assert.That((int)enumerationParameterType["revisionNumber"], Is.EqualTo(1));
             Assert.That((string)enumerationParameterType["classKind"], Is.EqualTo("EnumerationParameterType"));
 
-            Assert.IsFalse((bool) enumerationParameterType["isDeprecated"]);
+            Assert.That((bool) enumerationParameterType["isDeprecated"], Is.False);
             Assert.That((string)enumerationParameterType["name"], Is.EqualTo("Test Enumeration ParameterType"));
             Assert.That((string)enumerationParameterType["shortName"], Is.EqualTo("TestEnumerationParameterType"));
 
-            Assert.IsFalse((bool) enumerationParameterType["allowMultiSelect"]);
+            Assert.That((bool) enumerationParameterType["allowMultiSelect"], Is.False);
 
             var expectedValueDefinitions = new List<OrderedItem>
             {

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/FileType/FileTypeTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/FileType/FileTypeTestFixture.cs
@@ -90,7 +90,7 @@ namespace WebservicesIntegrationTests
             Assert.That((int)fileType[PropertyNames.RevisionNumber], Is.EqualTo(1));
             Assert.That((string)fileType[PropertyNames.ClassKind], Is.EqualTo("FileType"));
 
-            Assert.IsFalse((bool)fileType[PropertyNames.IsDeprecated]);
+            Assert.That((bool)fileType[PropertyNames.IsDeprecated], Is.False);
             Assert.That((string)fileType[PropertyNames.Name], Is.EqualTo("Test File Type"));
             Assert.That((string)fileType[PropertyNames.ShortName], Is.EqualTo("TestFileType"));
 
@@ -126,7 +126,7 @@ namespace WebservicesIntegrationTests
             Assert.That((int)fileType[PropertyNames.RevisionNumber], Is.EqualTo(1));
             Assert.That((string)fileType[PropertyNames.ClassKind], Is.EqualTo("FileType"));
 
-            Assert.IsFalse((bool)fileType[PropertyNames.IsDeprecated]);
+            Assert.That((bool)fileType[PropertyNames.IsDeprecated], Is.False);
             Assert.That((string)fileType[PropertyNames.Name], Is.EqualTo("Test Text Type"));
             Assert.That((string)fileType[PropertyNames.ShortName], Is.EqualTo("Text"));
 
@@ -163,7 +163,7 @@ namespace WebservicesIntegrationTests
             Assert.That((int)fileType[PropertyNames.RevisionNumber], Is.EqualTo(1));
             Assert.That((string)fileType[PropertyNames.ClassKind], Is.EqualTo("FileType"));
 
-            Assert.IsFalse((bool)fileType[PropertyNames.IsDeprecated]);
+            Assert.That((bool)fileType[PropertyNames.IsDeprecated], Is.False);
             Assert.That((string)fileType[PropertyNames.Name], Is.EqualTo("Test Unknown Type"));
             Assert.That((string)fileType[PropertyNames.ShortName], Is.EqualTo("Unknown"));
 

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/Glossary/GlossaryTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/Glossary/GlossaryTestFixture.cs
@@ -93,7 +93,7 @@ namespace WebservicesIntegrationTests
             Assert.That((int)glossary[PropertyNames.RevisionNumber], Is.EqualTo(1));
             Assert.That((string)glossary[PropertyNames.ClassKind], Is.EqualTo("Glossary"));
 
-            Assert.IsFalse((bool) glossary[PropertyNames.IsDeprecated]);
+            Assert.That((bool) glossary[PropertyNames.IsDeprecated], Is.False);
             Assert.That((string)glossary[PropertyNames.Name], Is.EqualTo("Test Glossary"));
             Assert.That((string)glossary[PropertyNames.ShortName], Is.EqualTo("TestGlossary"));
 
@@ -142,11 +142,11 @@ namespace WebservicesIntegrationTests
 
             var glossary = jArray.Single(x => (string)x[PropertyNames.Iid] == "bb08686b-ae03-49eb-9f48-c196b5ad6bda");
             Assert.That((int)glossary[PropertyNames.RevisionNumber], Is.EqualTo(2));
-            Assert.IsTrue((bool)glossary[PropertyNames.IsDeprecated]);
+            Assert.That((bool)glossary[PropertyNames.IsDeprecated], Is.True);
 
             var term = jArray.Single(x => (string)x[PropertyNames.Iid] == "18533006-1b9b-46c1-acc9-ae438ed4ebb2");
             Assert.That((int)term[PropertyNames.RevisionNumber], Is.EqualTo(2));
-            Assert.IsTrue((bool)term[PropertyNames.IsDeprecated]);
+            Assert.That((bool)term[PropertyNames.IsDeprecated], Is.True);
 
             Assert.That(jArray.Count, Is.EqualTo(3));
         }

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/IntervalScale/IntervalScaleTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/IntervalScale/IntervalScaleTestFixture.cs
@@ -96,7 +96,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) intervalScale["name"], Is.EqualTo("Test Interval Scale"));
             Assert.That((string) intervalScale["shortName"], Is.EqualTo("TestIntervalScale"));
 
-            Assert.IsFalse((bool) intervalScale["isDeprecated"]);
+            Assert.That((bool) intervalScale["isDeprecated"], Is.False);
             Assert.That((string) intervalScale["unit"], Is.EqualTo("56842970-3915-4369-8712-61cfd8273ef9"));
 
             var expectedValueDefinitions = new string[] {};
@@ -106,9 +106,9 @@ namespace WebservicesIntegrationTests
 
             Assert.That((string) intervalScale["numberSet"], Is.EqualTo("NATURAL_NUMBER_SET"));
             Assert.That((string) intervalScale["minimumPermissibleValue"], Is.EqualTo("1"));
-            Assert.IsTrue((bool) intervalScale["isMinimumInclusive"]);
+            Assert.That((bool) intervalScale["isMinimumInclusive"], Is.True);
             Assert.That((string) intervalScale["maximumPermissibleValue"], Is.EqualTo("2"));
-            Assert.IsTrue((bool) intervalScale["isMaximumInclusive"]);
+            Assert.That((bool) intervalScale["isMaximumInclusive"], Is.True);
             Assert.That((string) intervalScale["positiveValueConnotation"], Is.EqualTo("positive Value Connotation"));
             Assert.That((string) intervalScale["negativeValueConnotation"], Is.EqualTo("negative Value Connotation"));
 

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/LinearConversionUnit/LinearConversionUnitTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/LinearConversionUnit/LinearConversionUnitTestFixture.cs
@@ -93,7 +93,7 @@ namespace WebservicesIntegrationTests
             Assert.That((int) linearConversionUnit["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) linearConversionUnit["classKind"], Is.EqualTo("LinearConversionUnit"));
 
-            Assert.IsFalse((bool) linearConversionUnit["isDeprecated"]);
+            Assert.That((bool) linearConversionUnit["isDeprecated"], Is.False);
             Assert.That((string) linearConversionUnit["name"], Is.EqualTo("Test Linear Conversion Unit"));
             Assert.That((string) linearConversionUnit["shortName"], Is.EqualTo("testLinearConversionUnit"));
 

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/LogarithmicScale/LogarithmicScaleTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/LogarithmicScale/LogarithmicScaleTestFixture.cs
@@ -97,7 +97,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) logarithmicScale["shortName"], Is.EqualTo("TestLogarithmicScale"));
             Assert.That((string) logarithmicScale["shortName"], Is.EqualTo("TestLogarithmicScale"));
 
-            Assert.IsFalse((bool) logarithmicScale["isDeprecated"]);
+            Assert.That((bool) logarithmicScale["isDeprecated"], Is.False);
             Assert.That((string) logarithmicScale["unit"], Is.EqualTo("56842970-3915-4369-8712-61cfd8273ef9"));
 
             Assert.That((string) logarithmicScale["logarithmBase"], Is.EqualTo("BASE10"));
@@ -120,9 +120,9 @@ namespace WebservicesIntegrationTests
 
             Assert.That((string) logarithmicScale["numberSet"], Is.EqualTo("REAL_NUMBER_SET"));
             Assert.That((string) logarithmicScale["minimumPermissibleValue"], Is.EqualTo("0"));
-            Assert.IsFalse((bool) logarithmicScale["isMinimumInclusive"]);
+            Assert.That((bool) logarithmicScale["isMinimumInclusive"], Is.False);
             Assert.That((string) logarithmicScale["maximumPermissibleValue"], Is.Null);
-            Assert.IsTrue((bool) logarithmicScale["isMaximumInclusive"]);
+            Assert.That((bool) logarithmicScale["isMaximumInclusive"], Is.True);
             Assert.That(logarithmicScale["positiveValueConnotation"], Is.EqualTo(""));
             Assert.That(logarithmicScale["negativeValueConnotation"], Is.EqualTo(""));
             

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/MultirelationshipRule/MultirelationshipRuleTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/MultirelationshipRule/MultirelationshipRuleTestFixture.cs
@@ -93,7 +93,7 @@ namespace WebservicesIntegrationTests
             Assert.That((int) multirelationshipRule["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) multirelationshipRule["classKind"], Is.EqualTo("MultiRelationshipRule"));
 
-            Assert.IsFalse((bool) multirelationshipRule["isDeprecated"]);
+            Assert.That((bool) multirelationshipRule["isDeprecated"], Is.False);
             Assert.That((string) multirelationshipRule["name"], Is.EqualTo("Test Multi Relationship Rule"));
             Assert.That((string) multirelationshipRule["shortName"], Is.EqualTo("TestMultiRelationshipRule"));
 

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/OrdinalScale/OrdinalScaleTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/OrdinalScale/OrdinalScaleTestFixture.cs
@@ -93,11 +93,11 @@ namespace WebservicesIntegrationTests
             Assert.That((int) ordinalScale["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) ordinalScale["classKind"], Is.EqualTo("OrdinalScale"));
 
-            Assert.IsTrue((bool) ordinalScale["useShortNameValues"]);
+            Assert.That((bool) ordinalScale["useShortNameValues"], Is.True);
             Assert.That((string) ordinalScale["name"], Is.EqualTo("Test Ordinal Scale"));
             Assert.That((string) ordinalScale["shortName"], Is.EqualTo("TestOrdinalScale"));
 
-            Assert.IsFalse((bool) ordinalScale["isDeprecated"]);
+            Assert.That((bool) ordinalScale["isDeprecated"], Is.False);
             Assert.That((string) ordinalScale["unit"], Is.EqualTo("56842970-3915-4369-8712-61cfd8273ef9"));
 
             var expectedValueDefinitions = new string[]
@@ -110,9 +110,9 @@ namespace WebservicesIntegrationTests
 
             Assert.That((string) ordinalScale["numberSet"], Is.EqualTo("NATURAL_NUMBER_SET"));
             Assert.That((string) ordinalScale["minimumPermissibleValue"], Is.EqualTo("0"));
-            Assert.IsTrue((bool) ordinalScale["isMinimumInclusive"]);
+            Assert.That((bool) ordinalScale["isMinimumInclusive"], Is.True);
             Assert.That((string) ordinalScale["maximumPermissibleValue"], Is.EqualTo("100"));
-            Assert.IsTrue((bool) ordinalScale["isMaximumInclusive"]);
+            Assert.That((bool) ordinalScale["isMaximumInclusive"], Is.True);
             Assert.That((string) ordinalScale["positiveValueConnotation"], Is.EqualTo("positive Value Connotation"));
             Assert.That((string) ordinalScale["negativeValueConnotation"], Is.EqualTo("negative Value Connotation"));
 

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/Organization/OrganizationTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/Organization/OrganizationTestFixture.cs
@@ -87,7 +87,7 @@ namespace WebservicesIntegrationTests
             // assert that the properties are what is expected
             Assert.That((string)organization[PropertyNames.Name], Is.EqualTo("Test Organization"));
             Assert.That((string)organization[PropertyNames.ShortName], Is.EqualTo("TestOrganization"));
-            Assert.IsFalse((bool)organization[PropertyNames.IsDeprecated]);
+            Assert.That((bool)organization[PropertyNames.IsDeprecated], Is.False);
         }
     }
 }

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/ParameterizedCategoryRule/ParameterizedCategoryRuleTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/ParameterizedCategoryRule/ParameterizedCategoryRuleTestFixture.cs
@@ -93,7 +93,7 @@ namespace WebservicesIntegrationTests
             Assert.That((int) parameterizedCategoryRule["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) parameterizedCategoryRule["classKind"], Is.EqualTo("ParameterizedCategoryRule"));
 
-            Assert.IsFalse((bool) parameterizedCategoryRule["isDeprecated"]);
+            Assert.That((bool) parameterizedCategoryRule["isDeprecated"], Is.False);
             Assert.That((string) parameterizedCategoryRule["name"], Is.EqualTo("TestParameterizedCategoryRule"));
             Assert.That((string) parameterizedCategoryRule["shortName"], Is.EqualTo("Test Parameterized Category Rule"));
 

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/Participant/ParticipantTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/Participant/ParticipantTestFixture.cs
@@ -42,7 +42,7 @@ namespace WebservicesIntegrationTests
             var exception = Assert.Catch<WebException>(() => this.WebClient.PostDto(participantUri, postBody));
             var errorMessage = this.WebClient.ExtractExceptionStringFromResponse(exception.Response);
             Assert.That(((HttpWebResponse)exception.Response).StatusCode, Is.EqualTo(HttpStatusCode.Forbidden));
-            Assert.IsTrue(errorMessage.Contains("Participant selected domain must be contained in participant domain list."));
+            Assert.That(errorMessage, Does.Contain("Participant selected domain must be contained in participant domain list."));
         }
 
         [Test]
@@ -59,7 +59,7 @@ namespace WebservicesIntegrationTests
             var exception = Assert.Catch<WebException>(() => this.WebClient.PostDto(participantUri, postBody));
             var errorMessage = this.WebClient.ExtractExceptionStringFromResponse(exception.Response);
             Assert.That(((HttpWebResponse)exception.Response).StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
-            Assert.IsTrue(errorMessage.Contains("is already a Participant in EngineeringModel"));
+            Assert.That(errorMessage, Does.Contain("is already a Participant in EngineeringModel"));
         }
     }
 }

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/ParticipantPermission/ParticipantPermissionTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/ParticipantPermission/ParticipantPermissionTestFixture.cs
@@ -85,7 +85,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("c8656ec9-3377-4ea6-9d20-825e8f6fe335"));
             Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
-            Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
+            Assert.That((bool) participantPermissionObject["isDeprecated"], Is.False);
             Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
             Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("File"));
 
@@ -94,7 +94,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("8460a98f-6958-4caa-aa13-47b350e4bea9"));
             Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
-            Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
+            Assert.That((bool) participantPermissionObject["isDeprecated"], Is.False);
             Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
             Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("Parameter"));
 
@@ -103,7 +103,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("c3cf7ff9-4a4f-44a4-b91f-9918a12f664b"));
             Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
-            Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
+            Assert.That((bool) participantPermissionObject["isDeprecated"], Is.False);
             Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
             Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("Relationship"));
 
@@ -112,7 +112,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("8fdfec18-72d7-4e14-bcd1-5298f7594333"));
             Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
-            Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
+            Assert.That((bool) participantPermissionObject["isDeprecated"], Is.False);
             Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
             Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("ModelLogEntry"));
 
@@ -121,7 +121,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("b380b256-8938-4dab-98c5-554cb619e81b"));
             Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
-            Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
+            Assert.That((bool) participantPermissionObject["isDeprecated"], Is.False);
             Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
             Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("Iteration"));
 
@@ -130,7 +130,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("39a2a62a-655d-45c1-8b6f-6bad372f935b"));
             Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
-            Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
+            Assert.That((bool) participantPermissionObject["isDeprecated"], Is.False);
             Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
             Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("ElementUsage"));
 
@@ -139,7 +139,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("1bebf97d-114a-4baa-ba61-0f01eeb7e1ad"));
             Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
-            Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
+            Assert.That((bool) participantPermissionObject["isDeprecated"], Is.False);
             Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
             Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("RequirementsSpecification"));
 
@@ -148,7 +148,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("72cd93f4-e8f7-446b-a369-838b5a1ecc57"));
             Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
-            Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
+            Assert.That((bool) participantPermissionObject["isDeprecated"], Is.False);
             Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
             Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("ParameterGroup"));
 
@@ -157,7 +157,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("4ac0b072-8d58-46e0-8073-a48013c4c5be"));
             Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
-            Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
+            Assert.That((bool) participantPermissionObject["isDeprecated"], Is.False);
             Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
             Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("ExternalIdentifierMap"));
 
@@ -166,7 +166,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("bc7a0939-d6ee-4a08-9bb5-c350755dcd0d"));
             Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
-            Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
+            Assert.That((bool) participantPermissionObject["isDeprecated"], Is.False);
             Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
             Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("RequirementsGroup"));
 
@@ -175,7 +175,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("0145d47c-2971-4f89-9dc8-2c5e0453805e"));
             Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
-            Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
+            Assert.That((bool) participantPermissionObject["isDeprecated"], Is.False);
             Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
             Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("ElementDefinition"));
 
@@ -184,7 +184,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("b9eefd51-9da8-4f3f-b67c-8259ebad3b72"));
             Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
-            Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
+            Assert.That((bool) participantPermissionObject["isDeprecated"], Is.False);
             Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
             Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("ParameterOverride"));
 
@@ -193,7 +193,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("c189f7cb-056e-4659-affa-b3ff4f6ba881"));
             Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
-            Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
+            Assert.That((bool) participantPermissionObject["isDeprecated"], Is.False);
             Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
             Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("NestedElement"));
 
@@ -202,7 +202,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("dbe6a4b9-3b14-4580-8d3a-33ddf325c651"));
             Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
-            Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
+            Assert.That((bool) participantPermissionObject["isDeprecated"], Is.False);
             Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
             Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("Requirement"));
 
@@ -211,7 +211,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("bd276630-1d3f-45d0-9aa5-0efb9accbadb"));
             Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
-            Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
+            Assert.That((bool) participantPermissionObject["isDeprecated"], Is.False);
             Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
             Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("Publication"));
 
@@ -220,7 +220,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("df41e148-e228-4f19-b15a-2b68b75891e9"));
             Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
-            Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
+            Assert.That((bool) participantPermissionObject["isDeprecated"], Is.False);
             Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
             Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("NestedParameter"));
 
@@ -229,7 +229,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("ee7a7848-90d5-4914-b258-4a00c0543db0"));
             Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
-            Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
+            Assert.That((bool) participantPermissionObject["isDeprecated"], Is.False);
             Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
             Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("CommonFileStore"));
 
@@ -238,7 +238,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("ac6fe12e-fdaa-4b94-9822-312d0897f5cb"));
             Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
-            Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
+            Assert.That((bool) participantPermissionObject["isDeprecated"], Is.False);
             Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
             Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("ActualFiniteStateList"));
 
@@ -247,7 +247,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("f0bb5b06-b7b1-4e67-ae02-c71d73e71d00"));
             Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
-            Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
+            Assert.That((bool) participantPermissionObject["isDeprecated"], Is.False);
             Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
             Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("PossibleFiniteStateList"));
 
@@ -256,7 +256,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("7f8f6f00-1a3d-412c-a276-747306a4f961"));
             Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
-            Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
+            Assert.That((bool) participantPermissionObject["isDeprecated"], Is.False);
             Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
             Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("ParameterSubscription"));
 
@@ -265,7 +265,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("a18e23ea-77a1-481f-ad4a-b23a9022f93f"));
             Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
-            Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
+            Assert.That((bool) participantPermissionObject["isDeprecated"], Is.False);
             Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
             Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("Folder"));
 
@@ -274,7 +274,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("8f3627a8-7782-4b1c-8677-e546db6965a9"));
             Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
-            Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
+            Assert.That((bool) participantPermissionObject["isDeprecated"], Is.False);
             Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
             Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("RuleVerificationList"));
 
@@ -283,7 +283,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("af6526f8-66f4-4a0b-9c49-d9ae00e97108"));
             Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
-            Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
+            Assert.That((bool) participantPermissionObject["isDeprecated"], Is.False);
             Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
             Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("DomainFileStore"));
 
@@ -292,7 +292,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("939bdada-f827-4f27-8761-ba78918431dd"));
             Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
-            Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
+            Assert.That((bool) participantPermissionObject["isDeprecated"], Is.False);
             Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
             Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("EngineeringModel"));
         }

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/ParticipantRole/ParticipantRoleTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/ParticipantRole/ParticipantRoleTestFixture.cs
@@ -90,7 +90,7 @@ namespace WebservicesIntegrationTests
             
             Assert.That((string) participantRole["name"], Is.EqualTo("Test Participant Role"));
             Assert.That((string) participantRole["shortName"], Is.EqualTo("TestParticipantRole"));
-            Assert.IsFalse((bool) participantRole["isDeprecated"]);
+            Assert.That((bool) participantRole["isDeprecated"], Is.False);
 
             var expectedAliases = new string[] {};
             var aliasesArray = (JArray) participantRole["alias"];

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/Person/PersonTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/Person/PersonTestFixture.cs
@@ -232,12 +232,12 @@ namespace WebservicesIntegrationTests
             Assert.That((string)person[PropertyNames.OrganizationalUnit], Is.EqualTo(null));
             Assert.That((string)person[PropertyNames.Organization], Is.EqualTo(null));
             Assert.That((string)person[PropertyNames.DefaultDomain], Is.EqualTo(null));
-            Assert.IsFalse((bool)person[PropertyNames.IsActive]);
+            Assert.That((bool)person[PropertyNames.IsActive], Is.False);
             Assert.That((string)person[PropertyNames.Role], Is.EqualTo(null));
             Assert.That((string)person[PropertyNames.DefaultEmailAddress], Is.EqualTo(null));
             Assert.That((string)person[PropertyNames.DefaultTelephoneNumber], Is.EqualTo(null));
             Assert.That((string)person[PropertyNames.ShortName], Is.EqualTo("norole"));
-            Assert.IsFalse((bool)person[PropertyNames.IsDeprecated]);
+            Assert.That((bool)person[PropertyNames.IsDeprecated], Is.False);
 
             var expectedEmailAddresses = new string[]{};
             var emailAddresses = (JArray)person[PropertyNames.EmailAddress];
@@ -251,7 +251,7 @@ namespace WebservicesIntegrationTests
 
             var userPreferences = (JArray)person[PropertyNames.UserPreference];
             IList<string> up = userPreferences.Select(x => (string)x).ToList();
-            Assert.IsEmpty(up);
+            Assert.That(up, Is.Empty);
         }
 
         [Test]
@@ -300,7 +300,7 @@ namespace WebservicesIntegrationTests
             exception = Assert.Catch<WebException>(() => this.WebClient.GetDto(personWithEmptyPasswordUri));
             var errorMessage = this.WebClient.ExtractExceptionStringFromResponse(exception.Response);
             Assert.That(((HttpWebResponse)exception.Response).StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
-            Assert.IsTrue(errorMessage.Contains("SiteDirectory f13de6f8-b03a-46e7-a492-53b2f260f294 not found"));
+            Assert.That(errorMessage, Does.Contain("SiteDirectory f13de6f8-b03a-46e7-a492-53b2f260f294 not found"));
 
             var personWithPasswordUri = new Uri($"{this.Settings.Hostname}/SiteDirectory/f13de6f8-b03a-46e7-a492-53b2f260f294/person/01a6d208-7bb5-4855-a6fb-eb3d03f1337d");
 
@@ -308,7 +308,7 @@ namespace WebservicesIntegrationTests
             exception = Assert.Catch<WebException>(() => this.WebClient.GetDto(personWithPasswordUri));
             errorMessage = this.WebClient.ExtractExceptionStringFromResponse(exception.Response);
             Assert.That(((HttpWebResponse) exception.Response).StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
-            Assert.IsTrue(errorMessage.Contains("SiteDirectory f13de6f8-b03a-46e7-a492-53b2f260f294 not found"));
+            Assert.That(errorMessage, Does.Contain("SiteDirectory f13de6f8-b03a-46e7-a492-53b2f260f294 not found"));
         }
 
         /// <summary>
@@ -333,12 +333,12 @@ namespace WebservicesIntegrationTests
             Assert.That((string) person[PropertyNames.OrganizationalUnit], Is.EqualTo(""));
             Assert.That((string) person[PropertyNames.Organization], Is.EqualTo(null));
             Assert.That((string) person[PropertyNames.DefaultDomain], Is.EqualTo("0e92edde-fdff-41db-9b1d-f2e484f12535"));
-            Assert.IsTrue((bool) person[PropertyNames.IsActive]);
+            Assert.That((bool) person[PropertyNames.IsActive], Is.True);
             Assert.That((string) person[PropertyNames.Role], Is.EqualTo("2428f4d9-f26d-4112-9d56-1c940748df69"));
             Assert.That((string) person[PropertyNames.DefaultEmailAddress], Is.EqualTo(null));
             Assert.That((string) person[PropertyNames.DefaultTelephoneNumber], Is.EqualTo(null));
             Assert.That((string) person[PropertyNames.ShortName], Is.EqualTo("admin"));
-            Assert.IsFalse((bool) person[PropertyNames.IsDeprecated]);
+            Assert.That((bool) person[PropertyNames.IsDeprecated], Is.False);
 
             // verify that there are 2 emailAddresses for this person
             var expectedEmailAddresses = new string[]
@@ -363,7 +363,7 @@ namespace WebservicesIntegrationTests
             // verify that there are no userPreference for this person
             var userPreferences = (JArray) person[PropertyNames.UserPreference];
             IList<string> up = userPreferences.Select(x => (string) x).ToList();
-            Assert.IsEmpty(up);
+            Assert.That(up, Is.Empty);
         }
 
         [Test]

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/PersonPermission/PersonPermissionTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/PersonPermission/PersonPermissionTestFixture.cs
@@ -84,7 +84,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) personPermissionObject["iid"], Is.EqualTo("9211fa6a-ea92-43fc-bf2e-799ffd4b05ac"));
             Assert.That((int) personPermissionObject["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) personPermissionObject["classKind"], Is.EqualTo("PersonPermission"));
-            Assert.IsFalse((bool) personPermissionObject["isDeprecated"]);
+            Assert.That((bool) personPermissionObject["isDeprecated"], Is.False);
             Assert.That((string) personPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
             Assert.That((string) personPermissionObject["objectClass"], Is.EqualTo("ModelReferenceDataLibrary"));
 
@@ -92,7 +92,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) personPermissionObject["iid"], Is.EqualTo("a59e0ad9-bde7-4aeb-9871-e440380c44ed"));
             Assert.That((int) personPermissionObject["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) personPermissionObject["classKind"], Is.EqualTo("PersonPermission"));
-            Assert.IsFalse((bool) personPermissionObject["isDeprecated"]);
+            Assert.That((bool) personPermissionObject["isDeprecated"], Is.False);
             Assert.That((string) personPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
             Assert.That((string) personPermissionObject["objectClass"], Is.EqualTo("DomainOfExpertiseGroup"));
 
@@ -100,7 +100,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) personPermissionObject["iid"], Is.EqualTo("47b4f696-cbe6-411b-b0dd-1550207aa798"));
             Assert.That((int) personPermissionObject["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) personPermissionObject["classKind"], Is.EqualTo("PersonPermission"));
-            Assert.IsFalse((bool) personPermissionObject["isDeprecated"]);
+            Assert.That((bool) personPermissionObject["isDeprecated"], Is.False);
             Assert.That((string) personPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
             Assert.That((string) personPermissionObject["objectClass"], Is.EqualTo("Participant"));
 
@@ -108,7 +108,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) personPermissionObject["iid"], Is.EqualTo("007e23c2-62c4-459d-8cb1-499d9d014bdc"));
             Assert.That((int) personPermissionObject["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) personPermissionObject["classKind"], Is.EqualTo("PersonPermission"));
-            Assert.IsFalse((bool) personPermissionObject["isDeprecated"]);
+            Assert.That((bool) personPermissionObject["isDeprecated"], Is.False);
             Assert.That((string) personPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
             Assert.That((string) personPermissionObject["objectClass"], Is.EqualTo("SiteDirectory"));
 
@@ -116,7 +116,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) personPermissionObject["iid"], Is.EqualTo("0ec4ea88-3d84-411c-9a4a-0b1fb546281e"));
             Assert.That((int) personPermissionObject["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) personPermissionObject["classKind"], Is.EqualTo("PersonPermission"));
-            Assert.IsFalse((bool) personPermissionObject["isDeprecated"]);
+            Assert.That((bool) personPermissionObject["isDeprecated"], Is.False);
             Assert.That((string) personPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
             Assert.That((string) personPermissionObject["objectClass"], Is.EqualTo("ParticipantPermission"));
 
@@ -124,7 +124,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) personPermissionObject["iid"], Is.EqualTo("163e6bc3-4639-4204-9a5f-4266baafd25f"));
             Assert.That((int) personPermissionObject["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) personPermissionObject["classKind"], Is.EqualTo("PersonPermission"));
-            Assert.IsFalse((bool) personPermissionObject["isDeprecated"]);
+            Assert.That((bool) personPermissionObject["isDeprecated"], Is.False);
             Assert.That((string) personPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
             Assert.That((string) personPermissionObject["objectClass"], Is.EqualTo("PersonPermission"));
 
@@ -132,7 +132,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) personPermissionObject["iid"], Is.EqualTo("c5c23adb-82d6-4d6e-9192-183dbd67e022"));
             Assert.That((int) personPermissionObject["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) personPermissionObject["classKind"], Is.EqualTo("PersonPermission"));
-            Assert.IsFalse((bool) personPermissionObject["isDeprecated"]);
+            Assert.That((bool) personPermissionObject["isDeprecated"], Is.False);
             Assert.That((string) personPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
             Assert.That((string) personPermissionObject["objectClass"], Is.EqualTo("Person"));
 
@@ -140,7 +140,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) personPermissionObject["iid"], Is.EqualTo("272c94f3-8fe4-44c4-a915-616a0d93db26"));
             Assert.That((int) personPermissionObject["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) personPermissionObject["classKind"], Is.EqualTo("PersonPermission"));
-            Assert.IsFalse((bool) personPermissionObject["isDeprecated"]);
+            Assert.That((bool) personPermissionObject["isDeprecated"], Is.False);
             Assert.That((string) personPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
             Assert.That((string) personPermissionObject["objectClass"], Is.EqualTo("IterationSetup"));
 
@@ -148,7 +148,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) personPermissionObject["iid"], Is.EqualTo("6d336a9b-c4c3-44aa-8e96-17d9f626f3d7"));
             Assert.That((int) personPermissionObject["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) personPermissionObject["classKind"], Is.EqualTo("PersonPermission"));
-            Assert.IsFalse((bool) personPermissionObject["isDeprecated"]);
+            Assert.That((bool) personPermissionObject["isDeprecated"], Is.False);
             Assert.That((string) personPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
             Assert.That((string) personPermissionObject["objectClass"], Is.EqualTo("EngineeringModelSetup"));
 
@@ -156,7 +156,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) personPermissionObject["iid"], Is.EqualTo("db0e0a1d-c182-4c49-b375-abacfb77b5a5"));
             Assert.That((int) personPermissionObject["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) personPermissionObject["classKind"], Is.EqualTo("PersonPermission"));
-            Assert.IsFalse((bool) personPermissionObject["isDeprecated"]);
+            Assert.That((bool) personPermissionObject["isDeprecated"], Is.False);
             Assert.That((string) personPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
             Assert.That((string) personPermissionObject["objectClass"], Is.EqualTo("SiteReferenceDataLibrary"));
 
@@ -164,7 +164,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) personPermissionObject["iid"], Is.EqualTo("9108f724-fa36-49c2-a589-e5e3f1e98be1"));
             Assert.That((int) personPermissionObject["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) personPermissionObject["classKind"], Is.EqualTo("PersonPermission"));
-            Assert.IsFalse((bool) personPermissionObject["isDeprecated"]);
+            Assert.That((bool) personPermissionObject["isDeprecated"], Is.False);
             Assert.That((string) personPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
             Assert.That((string) personPermissionObject["objectClass"], Is.EqualTo("DomainOfExpertise"));
 
@@ -172,7 +172,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) personPermissionObject["iid"], Is.EqualTo("1f56c492-8ce5-44a0-82eb-d515ac8653f7"));
             Assert.That((int) personPermissionObject["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) personPermissionObject["classKind"], Is.EqualTo("PersonPermission"));
-            Assert.IsFalse((bool) personPermissionObject["isDeprecated"]);
+            Assert.That((bool) personPermissionObject["isDeprecated"], Is.False);
             Assert.That((string) personPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
             Assert.That((string) personPermissionObject["objectClass"], Is.EqualTo("Organization"));
 
@@ -180,7 +180,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) personPermissionObject["iid"], Is.EqualTo("e2c74973-a0e0-4212-96fe-4b0a236a07a0"));
             Assert.That((int) personPermissionObject["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) personPermissionObject["classKind"], Is.EqualTo("PersonPermission"));
-            Assert.IsFalse((bool) personPermissionObject["isDeprecated"]);
+            Assert.That((bool) personPermissionObject["isDeprecated"], Is.False);
             Assert.That((string) personPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
             Assert.That((string) personPermissionObject["objectClass"], Is.EqualTo("ParticipantRole"));
 
@@ -188,7 +188,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) personPermissionObject["iid"], Is.EqualTo("fc37edbf-c4e3-4902-bae5-533631f36e29"));
             Assert.That((int) personPermissionObject["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) personPermissionObject["classKind"], Is.EqualTo("PersonPermission"));
-            Assert.IsFalse((bool) personPermissionObject["isDeprecated"]);
+            Assert.That((bool) personPermissionObject["isDeprecated"], Is.False);
             Assert.That((string) personPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
             Assert.That((string) personPermissionObject["objectClass"], Is.EqualTo("PersonRole"));
 
@@ -196,7 +196,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) personPermissionObject["iid"], Is.EqualTo("98b924e2-3709-4b2c-b304-b74e3eab13af"));
             Assert.That((int) personPermissionObject["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) personPermissionObject["classKind"], Is.EqualTo("PersonPermission"));
-            Assert.IsFalse((bool) personPermissionObject["isDeprecated"]);
+            Assert.That((bool) personPermissionObject["isDeprecated"], Is.False);
             Assert.That((string) personPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
             Assert.That((string) personPermissionObject["objectClass"], Is.EqualTo("SiteLogEntry"));
         }

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/PersonRole/PersonRoleTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/PersonRole/PersonRoleTestFixture.cs
@@ -95,7 +95,7 @@ namespace WebservicesIntegrationTests
 
             Assert.That((string) personRole["name"], Is.EqualTo("Test Person Role"));
             Assert.That((string) personRole["shortName"], Is.EqualTo("TestPersonRole"));
-            Assert.IsFalse((bool) personRole["isDeprecated"]);
+            Assert.That((bool) personRole["isDeprecated"], Is.False);
 
             var expectedAliases = new string[] {};
             var aliasesArray = (JArray) personRole["alias"];

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/PrefixedUnit/PrefixedUnitTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/PrefixedUnit/PrefixedUnitTestFixture.cs
@@ -169,7 +169,7 @@ namespace WebservicesIntegrationTests
             Assert.That((int)siteReferenceDataLibrary[PropertyNames.RevisionNumber], Is.EqualTo(2));
             Assert.That((string)siteReferenceDataLibrary[PropertyNames.ClassKind], Is.EqualTo("SiteReferenceDataLibrary"));
 
-            Assert.IsFalse((bool)siteReferenceDataLibrary[PropertyNames.IsDeprecated]);
+            Assert.That((bool)siteReferenceDataLibrary[PropertyNames.IsDeprecated], Is.False);
             Assert.That((string)siteReferenceDataLibrary[PropertyNames.Name], Is.EqualTo("Test Reference Data Library"));
             Assert.That((string)siteReferenceDataLibrary[PropertyNames.ShortName], Is.EqualTo("TestRDL"));
 
@@ -302,7 +302,7 @@ namespace WebservicesIntegrationTests
             IList<string> rulesList = rulesArray.Select(x => (string)x).ToList();
             Assert.That(rulesList, Is.EquivalentTo(expectedRules));
 
-            Assert.IsEmpty(siteReferenceDataLibrary["requiredRdl"]);
+            Assert.That(siteReferenceDataLibrary["requiredRdl"], Is.Empty);
 
             var expectedConstants = new string[]
             {
@@ -323,7 +323,7 @@ namespace WebservicesIntegrationTests
             Assert.That((int)prefixedUnit[PropertyNames.RevisionNumber], Is.EqualTo(2));
             Assert.That((string)prefixedUnit[PropertyNames.ClassKind], Is.EqualTo("PrefixedUnit"));
 
-            Assert.IsFalse((bool)prefixedUnit[PropertyNames.IsDeprecated]);
+            Assert.That((bool)prefixedUnit[PropertyNames.IsDeprecated], Is.False);
             Assert.That((string)prefixedUnit[PropertyNames.Prefix], Is.EqualTo("efa6380d-9508-4f3d-9b43-6ed33125b780"));
             Assert.That((string)prefixedUnit[PropertyNames.ReferenceUnit], Is.EqualTo("56842970-3915-4369-8712-61cfd8273ef9"));
 
@@ -360,7 +360,7 @@ namespace WebservicesIntegrationTests
             Assert.That((int) prefixedUnit["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) prefixedUnit["classKind"], Is.EqualTo("PrefixedUnit"));
 
-            Assert.IsFalse((bool) prefixedUnit["isDeprecated"]);
+            Assert.That((bool) prefixedUnit["isDeprecated"], Is.False);
             Assert.That((string) prefixedUnit["prefix"], Is.EqualTo("efa6380d-9508-4f3d-9b43-6ed33125b780"));
             Assert.That((string) prefixedUnit["referenceUnit"], Is.EqualTo("56842970-3915-4369-8712-61cfd8273ef9"));
 

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/QuantityKind/QuantityKindTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/QuantityKind/QuantityKindTestFixture.cs
@@ -126,7 +126,7 @@ namespace WebservicesIntegrationTests
             Assert.That((int) siteReferenceDataLibrary[PropertyNames.RevisionNumber], Is.EqualTo(2));
             Assert.That((string) siteReferenceDataLibrary[PropertyNames.ClassKind], Is.EqualTo("SiteReferenceDataLibrary"));
 
-            Assert.IsFalse((bool) siteReferenceDataLibrary[PropertyNames.IsDeprecated]);
+            Assert.That((bool) siteReferenceDataLibrary[PropertyNames.IsDeprecated], Is.False);
             Assert.That((string) siteReferenceDataLibrary[PropertyNames.Name], Is.EqualTo("Test Reference Data Library"));
             Assert.That((string) siteReferenceDataLibrary[PropertyNames.ShortName], Is.EqualTo("TestRDL"));
 
@@ -276,7 +276,7 @@ namespace WebservicesIntegrationTests
             var rulesList = rulesArray.Select(x => (string) x).ToList();
             Assert.That(rulesList, Is.EquivalentTo(expectedRules));
 
-            Assert.IsEmpty(siteReferenceDataLibrary[PropertyNames.RequiredRdl]);
+            Assert.That(siteReferenceDataLibrary[PropertyNames.RequiredRdl], Is.Empty);
 
             var expectedConstants = new string[]
             {
@@ -302,7 +302,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) derivedQuantityKind[PropertyNames.Symbol], Is.EqualTo("testSymbol"));
             Assert.That((string) derivedQuantityKind[PropertyNames.QuantityDimensionSymbol], Is.EqualTo("testQuantityDimensionSymbol"));
             Assert.That((string) derivedQuantityKind[PropertyNames.DefaultScale], Is.EqualTo("53e82aeb-c42c-475c-b6bf-a102af883471"));
-            Assert.IsFalse((bool) derivedQuantityKind[PropertyNames.IsDeprecated]);
+            Assert.That((bool) derivedQuantityKind[PropertyNames.IsDeprecated], Is.False);
 
             var expectedQuantityKindFactors = new List<OrderedItem>
             {
@@ -355,7 +355,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) simpleQuantityKind[PropertyNames.Symbol], Is.EqualTo("testSymbol"));
             Assert.That((string) simpleQuantityKind[PropertyNames.QuantityDimensionSymbol], Is.EqualTo("testQuantityDimensionSymbol"));
             Assert.That((string) simpleQuantityKind[PropertyNames.DefaultScale], Is.EqualTo("53e82aeb-c42c-475c-b6bf-a102af883471"));
-            Assert.IsFalse((bool) simpleQuantityKind[PropertyNames.IsDeprecated]);
+            Assert.That((bool) simpleQuantityKind[PropertyNames.IsDeprecated], Is.False);
 
             var expectedSimpleCategories = new string[] { };
             var simpleCategoriesArray = (JArray) simpleQuantityKind[PropertyNames.Category];
@@ -399,7 +399,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string) specializedQuantityKind[PropertyNames.QuantityDimensionSymbol], Is.EqualTo("testQuantityDimensionSymbol"));
             Assert.That((string) specializedQuantityKind[PropertyNames.General], Is.EqualTo("199bec0a-661d-408c-8ca7-718c636c5681"));
             Assert.That((string) specializedQuantityKind[PropertyNames.DefaultScale], Is.EqualTo("53e82aeb-c42c-475c-b6bf-a102af883471"));
-            Assert.IsFalse((bool) specializedQuantityKind[PropertyNames.IsDeprecated]);
+            Assert.That((bool) specializedQuantityKind[PropertyNames.IsDeprecated], Is.False);
 
             var expectedSpecializedCategories = new string[] { };
             var specializedCategoriesArray = (JArray) specializedQuantityKind[PropertyNames.Category];

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/RatioScale/RatioScaleTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/RatioScale/RatioScaleTestFixture.cs
@@ -93,7 +93,7 @@ namespace WebservicesIntegrationTests.Tests.SiteDirectory.RatioScale
             Assert.That((int) ratioScale["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) ratioScale["classKind"], Is.EqualTo("RatioScale"));
 
-            Assert.IsFalse((bool) ratioScale["isDeprecated"]);
+            Assert.That((bool) ratioScale["isDeprecated"], Is.False);
             Assert.That((string) ratioScale["name"], Is.EqualTo("Test Ratio Scale"));
             Assert.That((string) ratioScale["shortName"], Is.EqualTo("TestRatioScale"));
 
@@ -106,9 +106,9 @@ namespace WebservicesIntegrationTests.Tests.SiteDirectory.RatioScale
 
             Assert.That((string) ratioScale["numberSet"], Is.EqualTo("REAL_NUMBER_SET"));
             Assert.That((string) ratioScale["minimumPermissibleValue"], Is.Null);
-            Assert.IsTrue((bool) ratioScale["isMinimumInclusive"]);
+            Assert.That((bool) ratioScale["isMinimumInclusive"], Is.True);
             Assert.That((string) ratioScale["maximumPermissibleValue"], Is.Null);
-            Assert.IsTrue((bool) ratioScale["isMaximumInclusive"]);
+            Assert.That((bool) ratioScale["isMaximumInclusive"], Is.True);
             Assert.That((string) ratioScale["positiveValueConnotation"], Is.Null);
             Assert.That((string) ratioScale["negativeValueConnotation"], Is.Null);
 

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/ReferenceSource/ReferenceSourceTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/ReferenceSource/ReferenceSourceTestFixture.cs
@@ -169,7 +169,7 @@ namespace WebservicesIntegrationTests
             Assert.That((int)siteReferenceDataLibrary[PropertyNames.RevisionNumber], Is.EqualTo(2));
             Assert.That((string)siteReferenceDataLibrary[PropertyNames.ClassKind], Is.EqualTo("SiteReferenceDataLibrary"));
 
-            Assert.IsFalse((bool)siteReferenceDataLibrary[PropertyNames.IsDeprecated]);
+            Assert.That((bool)siteReferenceDataLibrary[PropertyNames.IsDeprecated], Is.False);
             Assert.That((string)siteReferenceDataLibrary[PropertyNames.Name], Is.EqualTo("Test Reference Data Library"));
             Assert.That((string)siteReferenceDataLibrary[PropertyNames.ShortName], Is.EqualTo("TestRDL"));
 
@@ -302,7 +302,7 @@ namespace WebservicesIntegrationTests
             IList<string> rulesList = rulesArray.Select(x => (string)x).ToList();
             Assert.That(rulesList, Is.EquivalentTo(expectedRules));
 
-            Assert.IsEmpty(siteReferenceDataLibrary["requiredRdl"]);
+            Assert.That(siteReferenceDataLibrary["requiredRdl"], Is.Empty);
 
             var expectedConstants = new string[]
             {
@@ -324,7 +324,7 @@ namespace WebservicesIntegrationTests
             Assert.That((int)referenceSource[PropertyNames.RevisionNumber], Is.EqualTo(2));
             Assert.That((string)referenceSource[PropertyNames.ClassKind], Is.EqualTo("ReferenceSource"));
 
-            Assert.IsFalse((bool)referenceSource[PropertyNames.IsDeprecated]);
+            Assert.That((bool)referenceSource[PropertyNames.IsDeprecated], Is.False);
             Assert.That((string)referenceSource[PropertyNames.Name], Is.EqualTo("test referenceSource"));
             Assert.That((string)referenceSource[PropertyNames.ShortName], Is.EqualTo("testReferenceSource"));
 
@@ -373,7 +373,7 @@ namespace WebservicesIntegrationTests
             Assert.That((int) referenceSource[PropertyNames.RevisionNumber], Is.EqualTo(1));
             Assert.That((string) referenceSource[PropertyNames.ClassKind], Is.EqualTo("ReferenceSource"));
 
-            Assert.IsFalse((bool) referenceSource[PropertyNames.IsDeprecated]);
+            Assert.That((bool) referenceSource[PropertyNames.IsDeprecated], Is.False);
             Assert.That((string) referenceSource[PropertyNames.Name], Is.EqualTo("Test Reference Source"));
             Assert.That((string) referenceSource[PropertyNames.ShortName], Is.EqualTo("TestReferenceSource"));
 

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/ReferencerRule/ReferencerRuleTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/ReferencerRule/ReferencerRuleTestFixture.cs
@@ -93,7 +93,7 @@ namespace WebservicesIntegrationTests
             Assert.That((int) referencerRule["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) referencerRule["classKind"], Is.EqualTo("ReferencerRule"));
 
-            Assert.IsFalse((bool) referencerRule["isDeprecated"]);
+            Assert.That((bool) referencerRule["isDeprecated"], Is.False);
             Assert.That((string) referencerRule["name"], Is.EqualTo("TestReferencerRule"));
             Assert.That((string) referencerRule["shortName"], Is.EqualTo("Test Referencer Rule"));
 

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/SimpleQuantityKind/SimpleQuantityKindTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/SimpleQuantityKind/SimpleQuantityKindTestFixture.cs
@@ -93,7 +93,7 @@ namespace WebservicesIntegrationTests
             Assert.That((int) simpleQuantityKind[PropertyNames.RevisionNumber], Is.EqualTo(1));
             Assert.That((string) simpleQuantityKind[PropertyNames.ClassKind], Is.EqualTo("SimpleQuantityKind"));
 
-            Assert.IsFalse((bool) simpleQuantityKind[PropertyNames.IsDeprecated]);
+            Assert.That((bool) simpleQuantityKind[PropertyNames.IsDeprecated], Is.False);
             Assert.That((string) simpleQuantityKind[PropertyNames.Name], Is.EqualTo("Test Simple QuantityKind"));
             Assert.That((string) simpleQuantityKind[PropertyNames.ShortName], Is.EqualTo("TestSimpleQuantityKind"));
 

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/SimpleUnit/SimpleUnitTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/SimpleUnit/SimpleUnitTestFixture.cs
@@ -93,7 +93,7 @@ namespace WebservicesIntegrationTests
             Assert.That((int) simpleUnit["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) simpleUnit["classKind"], Is.EqualTo("SimpleUnit"));
 
-            Assert.IsFalse((bool) simpleUnit["isDeprecated"]);
+            Assert.That((bool) simpleUnit["isDeprecated"], Is.False);
             Assert.That((string) simpleUnit["name"], Is.EqualTo("test simple unit"));
             Assert.That((string) simpleUnit["shortName"], Is.EqualTo("testsimpleunit"));
 

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/SiteLogEntry/SiteLogEntryTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/SiteLogEntry/SiteLogEntryTestFixture.cs
@@ -85,14 +85,14 @@ namespace WebservicesIntegrationTests
             // verify that there are no affectedItemIid for this SiteLogEntry
             var affectedItemIids = (JArray) siteLogEntryObject[PropertyNames.AffectedItemIid];
             IList<string> affectedItemIidsList = affectedItemIids.Select(x => (string) x).ToList();
-            Assert.IsEmpty(affectedItemIidsList);
+            Assert.That(affectedItemIidsList, Is.Empty);
 
             Assert.That((string) siteLogEntryObject[PropertyNames.Author], Is.EqualTo("77791b12-4c2c-4499-93fa-869df3692d22"));
 
             // verify that there are no categories for this SiteLogEntry
             var categories = (JArray) siteLogEntryObject[PropertyNames.Category];
             IList<string> categoriesList = categories.Select(x => (string) x).ToList();
-            Assert.IsEmpty(categoriesList);
+            Assert.That(categoriesList, Is.Empty);
 
             Assert.That((string) siteLogEntryObject[PropertyNames.Content], Is.EqualTo("TestLogEntry"));
             Assert.That((string) siteLogEntryObject[PropertyNames.LanguageCode], Is.EqualTo("en-GB"));
@@ -108,14 +108,14 @@ namespace WebservicesIntegrationTests
             // verify that there are no affectedItemIid for this SiteLogEntry
             affectedItemIids = (JArray) siteLogEntryObject[PropertyNames.AffectedItemIid];
             affectedItemIidsList = affectedItemIids.Select(x => (string) x).ToList();
-            Assert.IsEmpty(affectedItemIidsList);
+            Assert.That(affectedItemIidsList, Is.Empty);
 
             Assert.That((string) siteLogEntryObject[PropertyNames.Author], Is.EqualTo("77791b12-4c2c-4499-93fa-869df3692d22"));
 
             // verify that there are no categories for this SiteLogEntry
             categories = (JArray) siteLogEntryObject[PropertyNames.Category];
             categoriesList = categories.Select(x => (string) x).ToList();
-            Assert.IsEmpty(categoriesList);
+            Assert.That(categoriesList, Is.Empty);
 
             Assert.That((string) siteLogEntryObject[PropertyNames.Content], Is.EqualTo("TestLogEntry"));
             Assert.That((string) siteLogEntryObject[PropertyNames.LanguageCode], Is.EqualTo("en-GB"));

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/SiteReferenceDataLibrary/SiteReferenceDataLibraryTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/SiteReferenceDataLibrary/SiteReferenceDataLibraryTestFixture.cs
@@ -118,7 +118,7 @@ namespace WebservicesIntegrationTests
 
             // get a specific SimpleUnit from the result by it's unique id
             var simpleUnit = jArray.Single(x => (string)x["iid"] == "56842970-3915-4369-8712-61cfd8273ef9");
-            Assert.IsTrue((bool)simpleUnit["isDeprecated"]);
+            Assert.That((bool)simpleUnit["isDeprecated"], Is.True);
         }
 
         /// <summary>
@@ -138,7 +138,7 @@ namespace WebservicesIntegrationTests
             Assert.That((int) siteReferenceDataLibrary["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) siteReferenceDataLibrary["classKind"], Is.EqualTo("SiteReferenceDataLibrary"));
 
-            Assert.IsFalse((bool) siteReferenceDataLibrary["isDeprecated"]);
+            Assert.That((bool) siteReferenceDataLibrary["isDeprecated"], Is.False);
             Assert.That((string) siteReferenceDataLibrary["name"], Is.EqualTo("Test Reference Data Library"));
             Assert.That((string) siteReferenceDataLibrary["shortName"], Is.EqualTo("TestRDL"));
 
@@ -270,7 +270,7 @@ namespace WebservicesIntegrationTests
             IList<string> rulesList = rulesArray.Select(x => (string) x).ToList();
             Assert.That(rulesList, Is.EquivalentTo(expectedRules));
 
-            Assert.IsEmpty(siteReferenceDataLibrary["requiredRdl"]);
+            Assert.That(siteReferenceDataLibrary["requiredRdl"], Is.Empty);
 
             var expectedConstants = new string[]
             {

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/SpecializedQuantityKind/SpecializedQuantityKindTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/SpecializedQuantityKind/SpecializedQuantityKindTestFixture.cs
@@ -93,7 +93,7 @@ namespace WebservicesIntegrationTests
             Assert.That((int) specializedQuantityKind[PropertyNames.RevisionNumber], Is.EqualTo(1));
             Assert.That((string) specializedQuantityKind[PropertyNames.ClassKind], Is.EqualTo("SpecializedQuantityKind"));
 
-            Assert.IsFalse((bool) specializedQuantityKind[PropertyNames.IsDeprecated]);
+            Assert.That((bool) specializedQuantityKind[PropertyNames.IsDeprecated], Is.False);
             Assert.That((string) specializedQuantityKind[PropertyNames.Name], Is.EqualTo("Test Specialized QuantityKind"));
             Assert.That((string) specializedQuantityKind[PropertyNames.ShortName], Is.EqualTo("TestSpecializedQuantityKind"));
 

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/TelephoneNumber/TelephoneNumberTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/TelephoneNumber/TelephoneNumberTestFixture.cs
@@ -212,12 +212,12 @@ namespace WebservicesIntegrationTests
             Assert.That((string) person[PropertyNames.OrganizationalUnit], Is.EqualTo(""));
             Assert.That((string) person[PropertyNames.Organization], Is.EqualTo(null));
             Assert.That((string) person[PropertyNames.DefaultDomain], Is.EqualTo("0e92edde-fdff-41db-9b1d-f2e484f12535"));
-            Assert.IsTrue((bool) person[PropertyNames.IsActive]);
+            Assert.That((bool) person[PropertyNames.IsActive], Is.True);
             Assert.That((string) person[PropertyNames.Role], Is.EqualTo("2428f4d9-f26d-4112-9d56-1c940748df69"));
             Assert.That((string) person[PropertyNames.DefaultEmailAddress], Is.EqualTo(null));
             Assert.That((string) person[PropertyNames.DefaultTelephoneNumber], Is.EqualTo(null));
             Assert.That((string) person[PropertyNames.ShortName], Is.EqualTo("admin"));
-            Assert.IsFalse((bool) person[PropertyNames.IsDeprecated]);
+            Assert.That((bool) person[PropertyNames.IsDeprecated], Is.False);
 
             // verify that there are 2 emailAddresses for this person
             var expectedEmailAddresses = new string[]
@@ -245,7 +245,7 @@ namespace WebservicesIntegrationTests
             // verify that there are no userPreference for this person
             var userPreferences = (JArray) person[PropertyNames.UserPreference];
             IList<string> up = userPreferences.Select(x => (string) x).ToList();
-            Assert.IsEmpty(up);
+            Assert.That(up, Is.Empty);
 
             // get a specific telephoneNumber from the result by it's unique id
             var telephoneNumber =

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/Term/TermTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/Term/TermTestFixture.cs
@@ -93,7 +93,7 @@ namespace WebservicesIntegrationTests
             Assert.That((int) term["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) term["classKind"], Is.EqualTo("Term"));
 
-            Assert.IsFalse((bool) term["isDeprecated"]);
+            Assert.That((bool) term["isDeprecated"], Is.False);
             Assert.That((string) term["name"], Is.EqualTo("Test Term"));
             Assert.That((string) term["shortName"], Is.EqualTo("TestTerm"));
 

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/TextParameterType/TextParameterTypeTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/TextParameterType/TextParameterTypeTestFixture.cs
@@ -89,7 +89,7 @@ namespace WebservicesIntegrationTests
             Assert.That((int) textParameterType[PropertyNames.RevisionNumber], Is.EqualTo(1));
             Assert.That((string) textParameterType[PropertyNames.ClassKind], Is.EqualTo("TextParameterType"));
 
-            Assert.IsFalse((bool) textParameterType[PropertyNames.IsDeprecated]);
+            Assert.That((bool) textParameterType[PropertyNames.IsDeprecated], Is.False);
             Assert.That((string) textParameterType[PropertyNames.Name], Is.EqualTo("Test Text ParameterType"));
             Assert.That((string) textParameterType[PropertyNames.ShortName], Is.EqualTo("TestTextParameterType"));
 

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/TimeOfDayParameterType/TimeOfDayParameterTypeTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/TimeOfDayParameterType/TimeOfDayParameterTypeTestFixture.cs
@@ -93,7 +93,7 @@ namespace WebservicesIntegrationTests
             Assert.That((int) timeOfDayParameterType[PropertyNames.RevisionNumber], Is.EqualTo(1));
             Assert.That((string) timeOfDayParameterType[PropertyNames.ClassKind], Is.EqualTo("TimeOfDayParameterType"));
 
-            Assert.IsFalse((bool) timeOfDayParameterType[PropertyNames.IsDeprecated]);
+            Assert.That((bool) timeOfDayParameterType[PropertyNames.IsDeprecated], Is.False);
             Assert.That((string) timeOfDayParameterType[PropertyNames.Name], Is.EqualTo("Test Time Of Day ParameterType"));
             Assert.That((string) timeOfDayParameterType[PropertyNames.ShortName], Is.EqualTo("TestTimeOfDayParameterType"));
 

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/UnitPrefix/UnitPrefixTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/UnitPrefix/UnitPrefixTestFixture.cs
@@ -93,7 +93,7 @@ namespace WebservicesIntegrationTests
             Assert.That((int) unitPrefix["revisionNumber"], Is.EqualTo(1));
             Assert.That((string) unitPrefix["classKind"], Is.EqualTo("UnitPrefix"));
 
-            Assert.IsFalse((bool) unitPrefix["isDeprecated"]);
+            Assert.That((bool) unitPrefix["isDeprecated"], Is.False);
             Assert.That((string) unitPrefix["name"], Is.EqualTo("kilo"));
             Assert.That((string) unitPrefix["shortName"], Is.EqualTo("k"));
 


### PR DESCRIPTION
## Summary
- replace direct Assert.IsTrue/IsFalse/IsEmpty usages with Assert.That constraint syntax across integration test fixtures
- adjust string containment checks to use Does.Contain and standardize empty collection assertions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8fdd187148326b5339158ea6d66d1